### PR TITLE
Use and configure nginx

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,7 +26,7 @@ resources:
   nginx-image:
     type: oci-image
     description: OCI image for nginx
-    upstream-source: ubuntu/nginx:1.18-22.04_beta
+    upstream-source: ubuntu/nginx:1.24-24.04_beta
   nginx-prometheus-exporter-image:
     type: oci-image
     description: OCI image for nginx-prometheus-exporter

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,6 +16,22 @@ description: |
 summary: |
   Tempo is a distributed tracing backend by Grafana.
 
+containers:
+  nginx:
+    resource: nginx-image
+  nginx-prometheus-exporter:
+    resource: nginx-prometheus-exporter-image
+
+resources:
+  nginx-image:
+    type: oci-image
+    description: OCI image for nginx
+    upstream-source: ubuntu/nginx:1.18-22.04_beta
+  nginx-prometheus-exporter-image:
+    type: oci-image
+    description: OCI image for nginx-prometheus-exporter
+    upstream-source: nginx/nginx-prometheus-exporter:1.1.0
+
 links:
   # FIXME: create docs tree root
   documentation: https://discourse.charmhub.io/t/tempo-coordinator-k8s-docs-index

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ jsonschema==4.17.0
 lightkube==0.11.0
 lightkube-models==1.24.1.4
 tenacity==8.2.3
+# crossplane is a package from nginxinc to interact with the Nginx config
+crossplane
 
 # PYDEPS
 # lib/charms/tempo_k8s/v1/charm_tracing.py

--- a/src/charm.py
+++ b/src/charm.py
@@ -89,8 +89,9 @@ class TempoCoordinatorCharm(CharmBase):
             ],
         )
         # # Patch the juju-created Kubernetes service to contain the right ports
-        external_ports = tempo.get_external_ports(self.app.name)
-        self._service_patcher = KubernetesServicePatch(self, external_ports)
+        self.unit.set_ports(*self.tempo.all_ports.values())
+
+        # self._service_patcher = KubernetesServicePatch(self, external_ports)
         # Provide ability for Tempo to be scraped by Prometheus using prometheus_scrape
         self._scraping = MetricsEndpointProvider(
             self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -157,7 +157,7 @@ class TempoCoordinatorCharm(CharmBase):
         self.framework.observe(self.tempo_cluster.on.changed, self._on_tempo_cluster_changed)
 
         for evt in self.on.events().values():
-            self.framework.observe(evt, self._on_event)
+            self.framework.observe(evt, self._on_event)  # type: ignore
 
     ######################
     # UTILITY PROPERTIES #
@@ -394,7 +394,7 @@ class TempoCoordinatorCharm(CharmBase):
     def _on_nginx_prometheus_exporter_pebble_ready(self, _) -> None:
         self.nginx_prometheus_exporter.configure_pebble_layer()
 
-    def _on_event(self, event):
+    def _on_event(self, event) -> None:
         """A set of common configuration actions that should happen on every event."""
         if isinstance(event, CollectStatusEvent):
             return
@@ -426,7 +426,7 @@ class TempoCoordinatorCharm(CharmBase):
         # notify the cluster
         self._update_tempo_cluster()
 
-    def _update_tracing_relations(self):
+    def _update_tracing_relations(self) -> None:
         tracing_relations = self.model.relations["tracing"]
         if not tracing_relations:
             # todo: set waiting status and configure tempo to run without receivers if possible,
@@ -454,12 +454,12 @@ class TempoCoordinatorCharm(CharmBase):
         requested_receivers = requested_protocols.intersection(set(self.tempo.receiver_ports))
         return tuple(requested_receivers)
 
-    def server_cert(self):
+    def server_cert(self) -> str:
         """For charm tracing."""
         self._update_server_cert()
         return self.tempo.server_cert_path
 
-    def _update_server_cert(self):
+    def _update_server_cert(self) -> None:
         """Server certificate for charm tracing tls, if tls is enabled."""
         server_cert = Path(self.tempo.server_cert_path)
         if self.tls_available:
@@ -513,7 +513,7 @@ class TempoCoordinatorCharm(CharmBase):
 
         return endpoints
 
-    def _update_tempo_cluster(self):
+    def _update_tempo_cluster(self) -> None:
         """Build the config and publish everything to the application databag."""
         if not self._is_consistent:
             logger.error("skipped tempo cluster update: inconsistent state")

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,6 @@ import ops
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
-from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.observability_libs.v1.cert_handler import VAULT_SECRET_LABEL, CertHandler
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tempo_k8s.v1.charm_tracing import trace_charm
@@ -28,8 +27,8 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
 
 from coordinator import TempoCoordinator
-from nginx import CA_CERT_PATH, CERT_PATH, KEY_PATH, Nginx
-from nginx_prometheus_exporter import NGINX_PROMETHEUS_EXPORTER_PORT, NginxPrometheusExporter
+from nginx import Nginx
+from nginx_prometheus_exporter import NginxPrometheusExporter
 from tempo import Tempo
 from tempo_cluster import TempoClusterProvider
 
@@ -408,7 +407,6 @@ class TempoCoordinatorCharm(CharmBase):
         self._update_tempo_cluster()
         # update tracing relations
         self._update_tracing_relations()
-
 
     ###################
     # UTILITY METHODS #

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,7 +90,6 @@ class TempoCoordinatorCharm(CharmBase):
         # # Patch the juju-created Kubernetes service to contain the right ports
         self.unit.set_ports(*self.tempo.all_ports.values())
 
-        # self._service_patcher = KubernetesServicePatch(self, external_ports)
         # Provide ability for Tempo to be scraped by Prometheus using prometheus_scrape
         self._scraping = MetricsEndpointProvider(
             self,

--- a/src/nginx.py
+++ b/src/nginx.py
@@ -367,6 +367,10 @@ class Nginx:
                         "directive": "proxy_set_header",
                         "args": ["X-Scope-OrgID", "$ensured_x_scope_orgid"],
                     },
+                    {
+                        "directive": "proxy_set_header",
+                        "args": ["Host", "$host:$server_port"]
+                    },
                     # FIXME: use a suitable SERVER_NAME
                     {"directive": "server_name", "args": [self.server_name]},
                     {"directive": "ssl_certificate", "args": [CERT_PATH]},
@@ -386,6 +390,10 @@ class Nginx:
                 {
                     "directive": "proxy_set_header",
                     "args": ["X-Scope-OrgID", "$ensured_x_scope_orgid"],
+                },
+                {
+                    "directive": "proxy_set_header",
+                    "args": ["Host", "$host:$server_port"]
                 },
                 *self._locations(addresses_by_role),
             ],

--- a/src/nginx.py
+++ b/src/nginx.py
@@ -9,7 +9,6 @@ import crossplane
 from ops import CharmBase
 from ops.pebble import Layer, PathError, ProtocolError
 
-
 from tempo import Tempo
 from tempo_cluster import TempoClusterProvider, TempoRole
 
@@ -201,7 +200,7 @@ class Nginx:
 
         return nginx_upstreams
 
-    def _distributor_upstreams(self, address_set):
+    def _distributor_upstreams(self, address_set: Set[str]) -> List[Dict[str, Any]]:
         return [
             self._upstream("otlp-http", address_set, Tempo.receiver_ports["otlp_http"]),
             self._upstream("otlp-grpc", address_set, Tempo.receiver_ports["otlp_grpc"]),
@@ -211,13 +210,13 @@ class Nginx:
             ),
         ]
 
-    def _query_frontend_upstreams(self, address_set):
+    def _query_frontend_upstreams(self, address_set: Set[str]) -> List[Dict[str, Any]]:
         return [
             self._upstream("tempo-http", address_set, Tempo.server_ports["tempo_http"]),
             self._upstream("tempo-grpc", address_set, Tempo.server_ports["tempo_grpc"]),
         ]
 
-    def _upstream(self, role, address_set, port):
+    def _upstream(self, role: str, address_set: Set[str], port: int) -> Dict[str, Any]:
         return {
             "directive": "upstream",
             "args": [role],
@@ -256,7 +255,7 @@ class Nginx:
             ]
         return []
 
-    def _listen(self, port, ssl, http2):
+    def _listen(self, port: int, ssl: bool, http2: bool) -> List[Dict[str, Any]]:
         directives = []
         directives.append(
             {"directive": "listen", "args": self._listen_args(port, False, ssl, http2)}
@@ -266,7 +265,7 @@ class Nginx:
         )
         return directives
 
-    def _listen_args(self, port, ipv6, ssl, http2):
+    def _listen_args(self, port: int, ipv6: bool, ssl: bool, http2: bool) -> List[str]:
         args = []
         if ipv6:
             args.append(f"[::]:{port}")

--- a/src/nginx_prometheus_exporter.py
+++ b/src/nginx_prometheus_exporter.py
@@ -7,8 +7,6 @@ import logging
 from ops import CharmBase
 from ops.pebble import Layer
 
-from nginx import NGINX_PORT
-
 logger = logging.getLogger(__name__)
 
 NGINX_PROMETHEUS_EXPORTER_PORT = "9113"
@@ -38,7 +36,7 @@ class NginxPrometheusExporter:
                     "nginx": {
                         "override": "replace",
                         "summary": "nginx prometheus exporter",
-                        "command": f"nginx-prometheus-exporter --no-nginx.ssl-verify --web.listen-address=:{NGINX_PROMETHEUS_EXPORTER_PORT}  --nginx.scrape-uri={scheme}://127.0.0.1:{NGINX_PORT}/status",
+                        "command": f"nginx-prometheus-exporter --no-nginx.ssl-verify --web.listen-address=:{NGINX_PROMETHEUS_EXPORTER_PORT}  --nginx.scrape-uri={scheme}://127.0.0.1:3200/status",
                         "startup": "enabled",
                     }
                 },

--- a/src/nginx_prometheus_exporter.py
+++ b/src/nginx_prometheus_exporter.py
@@ -27,7 +27,7 @@ class NginxPrometheusExporter:
     @property
     def layer(self) -> Layer:
         """Return the Pebble layer for Nginx Prometheus exporter."""
-        scheme = "https" if self._charm._is_cert_available else "http"  # type: ignore
+        scheme = "https" if self._charm.tls_available else "http"  # type: ignore
         return Layer(
             {
                 "summary": "nginx prometheus exporter layer",

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -42,7 +42,7 @@ class Tempo:
 
     memberlist_port = 7946
 
-    server_ports = {
+    server_ports: Dict[str, int] = {
         "tempo_http": 3200,
         "tempo_grpc": 9096,  # default grpc listen port is 9095, but that conflicts with promtail.
     }

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -252,7 +252,6 @@ class Tempo:
                 # total trace retention
                 block_retention="720h",
                 compacted_block_retention="1h",
-                v2_out_buffer_bytes=5242880,
             )
         )
 

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -207,7 +207,9 @@ class Tempo:
                 endpoint=s3_config["endpoint"],
                 secret_key=s3_config["secret-key"],
             ),
-            block=tempo_config.Block(version="v2"),
+            # starting from Tempo 2.4, we need to use at least parquet v3 to have search capabilities (Grafana support)
+            # https://grafana.com/docs/tempo/latest/release-notes/v2-4/#vparquet3-is-now-the-default-block-format
+            block=tempo_config.Block(version="vParquet3"),
         )
         return tempo_config.Storage(trace=storage_config)
 

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -137,7 +137,6 @@ class Compaction(BaseModel):
     max_compaction_objects: int
     block_retention: str
     compacted_block_retention: str
-    v2_out_buffer_bytes: int
 
 
 class Compactor(BaseModel):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-import yaml
 from pytest import fixture
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,16 +19,6 @@ async def tempo_charm(ops_test: OpsTest):
     return charm
 
 
-@fixture(scope="module")
-def tempo_metadata(ops_test: OpsTest):
-    return yaml.safe_load(Path("./metadata.yaml").read_text())
-
-
-@fixture(scope="module")
-def tempo_oci_image(ops_test: OpsTest, tempo_metadata):
-    return tempo_metadata["resources"]["tempo-image"]["upstream-source"]
-
-
 @fixture(scope="module", autouse=True)
 def copy_charm_libs_into_tester_charm(ops_test):
     """Ensure the tester charm has the libraries it uses."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,6 +33,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
           {mc.name}:
             charm: {charm}
             trust: true
+            resources:
+              nginx-image: {METADATA["resources"]["nginx-image"]["upstream-source"]}
+              nginx-prometheus-exporter-image: {METADATA["resources"]["nginx-prometheus-exporter-image"]["upstream-source"]}
             scale: 1
           loki:
             charm: loki-k8s

--- a/tests/integration/test_scaling_monolithic.py
+++ b/tests/integration/test_scaling_monolithic.py
@@ -27,7 +27,9 @@ async def test_deploy_tempo(ops_test: OpsTest):
     tempo_charm = await ops_test.build_charm(".")
     resources = {
         "nginx-image": METADATA["resources"]["nginx-image"]["upstream-source"],
-        "nginx-prometheus-exporter-image": METADATA["resources"]["nginx-prometheus-exporter-image"]["upstream-source"],
+        "nginx-prometheus-exporter-image": METADATA["resources"][
+            "nginx-prometheus-exporter-image"
+        ]["upstream-source"],
     }
     await ops_test.model.deploy(tempo_charm, resources=resources, application_name=APP_NAME)
 

--- a/tests/integration/test_scaling_monolithic.py
+++ b/tests/integration/test_scaling_monolithic.py
@@ -25,7 +25,11 @@ logger = logging.getLogger(__name__)
 @pytest.mark.abort_on_fail
 async def test_deploy_tempo(ops_test: OpsTest):
     tempo_charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(tempo_charm, application_name=APP_NAME)
+    resources = {
+        "nginx-image": METADATA["resources"]["nginx-image"]["upstream-source"],
+        "nginx-prometheus-exporter-image": METADATA["resources"]["nginx-prometheus-exporter-image"]["upstream-source"],
+    }
+    await ops_test.model.deploy(tempo_charm, resources=resources, application_name=APP_NAME)
 
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -35,6 +35,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
             charm: {charm}
             trust: true
             scale: 1
+            resources:
+              nginx-image: {METADATA["resources"]["nginx-image"]["upstream-source"]}
+              nginx-prometheus-exporter-image: {METADATA["resources"]["nginx-prometheus-exporter-image"]["upstream-source"]}
           prom:
             charm: prometheus-k8s
             channel: edge

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -53,3 +53,11 @@ def nginx_container():
         "nginx",
         can_connect=True,
     )
+
+
+@pytest.fixture(scope="function")
+def nginx_prometheus_exporter_container():
+    return Container(
+        "nginx-prometheus-exporter",
+        can_connect=True,
+    )

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -9,10 +9,9 @@ from tempo_cluster import TempoClusterRequirerAppData, TempoRole
 
 @pytest.fixture
 def tempo_charm():
-    with patch("charm.KubernetesServicePatch"):
-        with patch("lightkube.core.client.GenericSyncClient"):
-            with patch("charm.TempoCoordinatorCharm._update_server_cert"):
-                yield TempoCoordinatorCharm
+    with patch("lightkube.core.client.GenericSyncClient"):
+        with patch("charm.TempoCoordinatorCharm._update_server_cert"):
+            yield TempoCoordinatorCharm
 
 
 @pytest.fixture(scope="function")

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from scenario import Context, Relation
+from scenario import Container, Context, Relation
 
 from charm import TempoCoordinatorCharm
 from tempo_cluster import TempoClusterRequirerAppData, TempoRole
@@ -44,4 +44,12 @@ def all_worker():
     return Relation(
         "tempo-cluster",
         remote_app_data=TempoClusterRequirerAppData(role=TempoRole.all).dump(),
+    )
+
+
+@pytest.fixture(scope="function")
+def nginx_container():
+    return Container(
+        "nginx",
+        can_connect=True,
     )

--- a/tests/scenario/test_charm_statuses.py
+++ b/tests/scenario/test_charm_statuses.py
@@ -34,12 +34,12 @@ def test_scaled_status_no_workers(context, all_worker):
     assert state_out.unit_status.name == "blocked"
 
 
-def test_scaled_status_with_s3_and_workers(context, s3, all_worker, nginx_container):
+def test_scaled_status_with_s3_and_workers(context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container):
     state_out = context.run(
         "start",
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}}), s3, all_worker],
-            containers=[nginx_container],
+            containers=[nginx_container, nginx_prometheus_exporter_container],
             unit_status=ops.ActiveStatus(),
         ),
     )
@@ -47,12 +47,12 @@ def test_scaled_status_with_s3_and_workers(context, s3, all_worker, nginx_contai
 
 
 @patch.object(Tempo, "is_ready", new=True)
-def test_happy_status(context, s3, all_worker, nginx_container):
+def test_happy_status(context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container):
     state_out = context.run(
         "start",
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}}), s3, all_worker],
-            containers=[nginx_container],
+            containers=[nginx_container, nginx_prometheus_exporter_container],
             unit_status=ops.ActiveStatus(),
         ),
     )

--- a/tests/scenario/test_charm_statuses.py
+++ b/tests/scenario/test_charm_statuses.py
@@ -1,14 +1,13 @@
 from unittest.mock import patch
 
 import ops
-
 from scenario import PeerRelation, State
 
 from tempo import Tempo
 
 
 def test_monolithic_status_no_s3_no_workers(context):
-    state_out = context.run("start", State(unit_status=ops.ActiveStatus()))
+    state_out = context.run("start", State(unit_status=ops.ActiveStatus(), leader=True))
     assert state_out.unit_status.name == "blocked"
 
 
@@ -34,26 +33,32 @@ def test_scaled_status_no_workers(context, all_worker):
     assert state_out.unit_status.name == "blocked"
 
 
-def test_scaled_status_with_s3_and_workers(context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container):
+def test_scaled_status_with_s3_and_workers(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
     state_out = context.run(
         "start",
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}}), s3, all_worker],
             containers=[nginx_container, nginx_prometheus_exporter_container],
             unit_status=ops.ActiveStatus(),
+            leader=True,
         ),
     )
     assert state_out.unit_status.name == "active"
 
 
 @patch.object(Tempo, "is_ready", new=True)
-def test_happy_status(context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container):
+def test_happy_status(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
     state_out = context.run(
         "start",
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}}), s3, all_worker],
             containers=[nginx_container, nginx_prometheus_exporter_container],
             unit_status=ops.ActiveStatus(),
+            leader=True,
         ),
     )
     assert state_out.unit_status.name == "active"

--- a/tests/scenario/test_charm_statuses.py
+++ b/tests/scenario/test_charm_statuses.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import ops
+
 from scenario import PeerRelation, State
 
 from tempo import Tempo
@@ -33,11 +34,12 @@ def test_scaled_status_no_workers(context, all_worker):
     assert state_out.unit_status.name == "blocked"
 
 
-def test_scaled_status_with_s3_and_workers(context, s3, all_worker):
+def test_scaled_status_with_s3_and_workers(context, s3, all_worker, nginx_container):
     state_out = context.run(
         "start",
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}}), s3, all_worker],
+            containers=[nginx_container],
             unit_status=ops.ActiveStatus(),
         ),
     )
@@ -45,11 +47,12 @@ def test_scaled_status_with_s3_and_workers(context, s3, all_worker):
 
 
 @patch.object(Tempo, "is_ready", new=True)
-def test_happy_status(context, s3, all_worker):
+def test_happy_status(context, s3, all_worker, nginx_container):
     state_out = context.run(
         "start",
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}}), s3, all_worker],
+            containers=[nginx_container],
             unit_status=ops.ActiveStatus(),
         ),
     )

--- a/tests/scenario/test_config.py
+++ b/tests/scenario/test_config.py
@@ -4,7 +4,9 @@ from charm import TempoCoordinatorCharm
 from tempo_cluster import TempoClusterRequirerUnitData
 
 
-def test_memberlist_multiple_members(context, all_worker, s3):
+def test_memberlist_multiple_members(
+    context, all_worker, s3, nginx_container, nginx_prometheus_exporter_container
+):
     workers_no = 3
     all_worker = all_worker.replace(
         remote_units_data={
@@ -23,7 +25,11 @@ def test_memberlist_multiple_members(context, all_worker, s3):
             for worker_idx in range(workers_no)
         },
     )
-    state = State(leader=True, relations=[all_worker, s3])
+    state = State(
+        leader=True,
+        relations=[all_worker, s3],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+    )
     with context.manager(all_worker.changed_event, state) as mgr:
         charm: TempoCoordinatorCharm = mgr.charm
         assert charm.tempo_cluster.gather_addresses() == set(

--- a/tests/scenario/test_ingressed_tracing.py
+++ b/tests/scenario/test_ingressed_tracing.py
@@ -9,8 +9,11 @@ from tempo import Tempo
 
 
 @pytest.fixture
-def base_state():
-    return State(leader=True)
+def base_state(nginx_container, nginx_prometheus_exporter_container):
+    return State(
+        leader=True,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+    )
 
 
 def test_external_url_present(context, base_state, s3, all_worker):

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -34,6 +34,7 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cl
     tempo_charm.unit = MagicMock(return_value=unit)
 
     nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
+    logger.info(nginx._prepare_config(tls=False))
 
     prepared_config = nginx.config(tls=False)
     assert isinstance(prepared_config, str)

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nginx import Nginx
+from tempo import Tempo
 from tempo_cluster import TempoClusterProvider
 
 logger = logging.getLogger(__name__)
@@ -96,3 +97,67 @@ def test_nginx_config_is_parsed_with_workers(
 
     prepared_config = nginx.config()
     assert isinstance(prepared_config, str)
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    (
+        {"all": {"1.2.3.4"}},
+        {"all": {"1.2.3.4", "1.2.3.5"}},
+        {
+            "all": {"1.2.3.4"},
+            "distributor": {"1.2.3.5"},
+            "ingester": {"1.2.3.6"},
+            "querier": {"1.2.4.7"},
+            "query_frontend": {"1.2.5.1"},
+            "compactor": {"1.2.6.6"},
+            "metrics_generator": {"1.2.8.4"},
+        },
+        {
+            "distributor": {"1.2.3.5"},
+            "ingester": {"1.2.3.6"},
+            "querier": {"1.2.4.7"},
+            "query_frontend": {"1.2.5.1"},
+            "compactor": {"1.2.6.6"},
+            "metrics_generator": {"1.2.8.4"},
+        },
+    ),
+)
+def test_nginx_config_contains_upstreams_and_proxy_pass(
+    context, nginx_container, tempo_cluster_provider, addresses
+):
+    tempo_cluster_provider.gather_addresses_by_role = MagicMock(return_value=addresses)
+
+    unit = MagicMock()
+    unit.get_container = nginx_container
+    tempo_charm = MagicMock()
+    tempo_charm.unit = MagicMock(return_value=unit)
+
+    nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
+
+    prepared_config = nginx.config()
+
+    for role, addresses in addresses.items():
+        for address in addresses:
+            if role == "all":
+                _assert_config_per_role(Tempo.all_ports, address, prepared_config)
+            if role == "distributor":
+                _assert_config_per_role(Tempo.receiver_ports, address, prepared_config)
+            if role == "query-frontend":
+                _assert_config_per_role(Tempo.server_ports, address, prepared_config)
+
+
+def _assert_config_per_role(source_dict, address, prepared_config):
+    # as entire config is in a format that's hard to parse (and crossplane returns a string), we look for servers,
+    # upstreams and correct proxy/grpc_pass instructions.
+    for port in source_dict.values():
+        assert f"server {address}:{port};" in prepared_config
+        assert f"listen {port}" in prepared_config
+        assert f"listen [::]:{port}" in prepared_config
+    for protocol in source_dict.keys():
+        sanitised_protocol = protocol.replace("_", "-")
+        assert f"upstream {sanitised_protocol}" in prepared_config
+        if "grpc" in protocol:
+            assert f"grpc_pass grpcs://{sanitised_protocol}" in prepared_config
+        else:
+            assert f"proxy_pass https://{sanitised_protocol}" in prepared_config

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -1,14 +1,14 @@
+import logging
 from typing import List
 from unittest.mock import MagicMock
 
-import logging
 import pytest
 
 from nginx import Nginx
 from tempo_cluster import TempoClusterProvider
 
-
 logger = logging.getLogger(__name__)
+
 
 @pytest.fixture
 def tempo_cluster_provider():
@@ -26,6 +26,7 @@ def test_nginx_config_is_list_before_crossplane(context, nginx_container, tempo_
 
     prepared_config = nginx._prepare_config(tls=False)
     assert isinstance(prepared_config, List)
+
 
 def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cluster_provider):
     unit = MagicMock()
@@ -53,7 +54,7 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cl
             "querier": {"1.2.4.7"},
             "query_frontend": {"1.2.5.1"},
             "compactor": {"1.2.6.6"},
-            "metrics_generator": {"1.2.8.4"}
+            "metrics_generator": {"1.2.8.4"},
         },
         {
             "distributor": {"1.2.3.5"},
@@ -61,7 +62,7 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cl
             "querier": {"1.2.4.7"},
             "query_frontend": {"1.2.5.1"},
             "compactor": {"1.2.6.6"},
-            "metrics_generator": {"1.2.8.4"}
+            "metrics_generator": {"1.2.8.4"},
         },
         {
             "distributor": {"1.2.3.5"},
@@ -69,7 +70,7 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cl
             "querier": {"1.2.4.7"},
             "query_frontend": {"1.2.5.1"},
             "compactor": {"1.2.6.6"},
-            "metrics_generator": {"1.2.8.4"}
+            "metrics_generator": {"1.2.8.4"},
         },
         {
             "distributor": {"1.2.3.5", "1.2.3.7"},
@@ -77,11 +78,13 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cl
             "querier": {"1.2.4.7", "1.2.4.9"},
             "query_frontend": {"1.2.5.1", "1.2.5.2"},
             "compactor": {"1.2.6.6", "1.2.6.7"},
-            "metrics_generator": {"1.2.8.4", "1.2.8.5"}
-        }
+            "metrics_generator": {"1.2.8.4", "1.2.8.5"},
+        },
     ),
 )
-def test_nginx_config_is_parsed_with_workers(context, nginx_container, tempo_cluster_provider, addresses):
+def test_nginx_config_is_parsed_with_workers(
+    context, nginx_container, tempo_cluster_provider, addresses
+):
     tempo_cluster_provider.gather_addresses_by_role = MagicMock(return_value=addresses)
 
     unit = MagicMock()

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -1,0 +1,30 @@
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import logging
+import ops
+import pytest
+from scenario import PeerRelation, State
+
+from nginx import Nginx
+from tempo_cluster import TempoClusterProvider
+
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def tempo_cluster_provider():
+    cluster_mock = MagicMock()
+    return TempoClusterProvider(cluster_mock)
+
+
+def test_nginx_config_is_list_before_crossplane(context, nginx_container, tempo_cluster_provider):
+    unit = MagicMock()
+    unit.get_container = nginx_container
+    tempo_charm = MagicMock()
+    tempo_charm.unit = MagicMock(return_value=unit)
+
+    nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
+
+    prepared_config = nginx._prepare_config(tls=False)
+    assert isinstance(prepared_config, List)

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -24,7 +24,7 @@ def test_nginx_config_is_list_before_crossplane(context, nginx_container, tempo_
 
     nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
 
-    prepared_config = nginx._prepare_config(tls=False)
+    prepared_config = nginx._prepare_config()
     assert isinstance(prepared_config, List)
 
 
@@ -35,9 +35,9 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cl
     tempo_charm.unit = MagicMock(return_value=unit)
 
     nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
-    logger.info(nginx._prepare_config(tls=False))
+    logger.info(nginx._prepare_config())
 
-    prepared_config = nginx.config(tls=False)
+    prepared_config = nginx.config()
     assert isinstance(prepared_config, str)
 
 
@@ -94,5 +94,5 @@ def test_nginx_config_is_parsed_with_workers(
 
     nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
 
-    prepared_config = nginx.config(tls=False)
+    prepared_config = nginx.config()
     assert isinstance(prepared_config, str)

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -1,10 +1,8 @@
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import logging
-import ops
 import pytest
-from scenario import PeerRelation, State
 
 from nginx import Nginx
 from tempo_cluster import TempoClusterProvider
@@ -28,3 +26,69 @@ def test_nginx_config_is_list_before_crossplane(context, nginx_container, tempo_
 
     prepared_config = nginx._prepare_config(tls=False)
     assert isinstance(prepared_config, List)
+
+def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, tempo_cluster_provider):
+    unit = MagicMock()
+    unit.get_container = nginx_container
+    tempo_charm = MagicMock()
+    tempo_charm.unit = MagicMock(return_value=unit)
+
+    nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
+
+    prepared_config = nginx.config(tls=False)
+    assert isinstance(prepared_config, str)
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    (
+        {},
+        {"all": {"1.2.3.4"}},
+        {"all": {"1.2.3.4", "1.2.3.5"}},
+        {
+            "all": {"1.2.3.4"},
+            "distributor": {"1.2.3.5"},
+            "ingester": {"1.2.3.6"},
+            "querier": {"1.2.4.7"},
+            "query_frontend": {"1.2.5.1"},
+            "compactor": {"1.2.6.6"},
+            "metrics_generator": {"1.2.8.4"}
+        },
+        {
+            "distributor": {"1.2.3.5"},
+            "ingester": {"1.2.3.6"},
+            "querier": {"1.2.4.7"},
+            "query_frontend": {"1.2.5.1"},
+            "compactor": {"1.2.6.6"},
+            "metrics_generator": {"1.2.8.4"}
+        },
+        {
+            "distributor": {"1.2.3.5"},
+            "ingester": {"1.2.3.6"},
+            "querier": {"1.2.4.7"},
+            "query_frontend": {"1.2.5.1"},
+            "compactor": {"1.2.6.6"},
+            "metrics_generator": {"1.2.8.4"}
+        },
+        {
+            "distributor": {"1.2.3.5", "1.2.3.7"},
+            "ingester": {"1.2.3.6", "1.2.3.8"},
+            "querier": {"1.2.4.7", "1.2.4.9"},
+            "query_frontend": {"1.2.5.1", "1.2.5.2"},
+            "compactor": {"1.2.6.6", "1.2.6.7"},
+            "metrics_generator": {"1.2.8.4", "1.2.8.5"}
+        }
+    ),
+)
+def test_nginx_config_is_parsed_with_workers(context, nginx_container, tempo_cluster_provider, addresses):
+    tempo_cluster_provider.gather_addresses_by_role = MagicMock(return_value=addresses)
+
+    unit = MagicMock()
+    unit.get_container = nginx_container
+    tempo_charm = MagicMock()
+    tempo_charm.unit = MagicMock(return_value=unit)
+
+    nginx = Nginx(tempo_charm, tempo_cluster_provider, "lolcathost")
+
+    prepared_config = nginx.config(tls=False)
+    assert isinstance(prepared_config, str)

--- a/tests/scenario/test_tls.py
+++ b/tests/scenario/test_tls.py
@@ -10,7 +10,7 @@ from charm import TempoCoordinatorCharm
 
 
 @pytest.fixture
-def base_state():
+def base_state(nginx_container, nginx_prometheus_exporter_container):
     return State(
         leader=True,
         secrets=[
@@ -23,6 +23,7 @@ def base_state():
                 contents={0: {"foo": "bar"}},
             )
         ],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
     )
 
 

--- a/tests/scenario/test_tracing_legacy.py
+++ b/tests/scenario/test_tracing_legacy.py
@@ -6,8 +6,11 @@ from scenario import Relation, State
 
 
 @pytest.fixture
-def base_state():
-    return State(leader=True)
+def base_state(nginx_container, nginx_prometheus_exporter_container):
+    return State(
+        leader=True,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+    )
 
 
 @pytest.mark.parametrize("evt_name", ("changed", "created", "joined"))

--- a/tests/scenario/test_tracing_provider.py
+++ b/tests/scenario/test_tracing_provider.py
@@ -3,7 +3,9 @@ from charms.tempo_k8s.v2.tracing import ProtocolType, TracingProviderAppData
 from scenario import Relation, State
 
 
-def test_receivers_removed_on_relation_broken(context, s3, all_worker):
+def test_receivers_removed_on_relation_broken(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
     tracing_grpc = Relation(
         "tracing",
         remote_app_data={"receivers": '["otlp_grpc"]'},
@@ -24,6 +26,7 @@ def test_receivers_removed_on_relation_broken(context, s3, all_worker):
     state = State(
         leader=True,
         relations=[tracing_grpc, tracing_http, s3, all_worker],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
     )
 
     with charm_tracing_disabled():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import patch
 
 from ops.testing import Harness
 
@@ -12,7 +11,6 @@ CONTAINER_NAME = "nginx"
 
 
 class TestTempoCoordinatorCharm(unittest.TestCase):
-    @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def setUp(self):
         self.harness = Harness(TempoCoordinatorCharm)
         self.harness.set_model_name("testmodel")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from ops.testing import Harness
 
 from charm import TempoCoordinatorCharm
 
-CONTAINER_NAME = "tempo"
+CONTAINER_NAME = "nginx"
 
 
 class TestTempoCoordinatorCharm(unittest.TestCase):
@@ -19,6 +19,8 @@ class TestTempoCoordinatorCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
+        self.harness.add_relation("s3", "s3-integrator")
+        self.harness.add_relation("tempo-cluster", "tempo-worker-k8s")
         self.maxDiff = None  # we're comparing big traefik configs in tests
 
     def test_entrypoints_are_generated_with_sanitized_names(self):


### PR DESCRIPTION
This PR configures nginx in a way so that all instances of tempo-worker are accessible on all possible ports and forward both the HTTP and GRPC traffic to correct upstreams.