### PR TITLE
translate tempo config to pydantic models

### DIFF
--- a/src/tempo.py
+++ b/src/tempo.py
@@ -187,12 +187,12 @@ class Tempo:
             )
             config.memberlist = config.memberlist.model_copy(update=tls_config)
 
-        return config.model_dump()
+        return config.model_dump(mode="json", exclude_none=True)
 
     def _build_storage_config(self, s3_config: dict):
         storage_config = tempo_config.TraceStorage(
             # where to store the wal locally
-            wal=tempo_config.Wal(path=self.wal_path),
+            wal=tempo_config.Wal(path=self.wal_path),  # type: ignore
             pool=tempo_config.Pool(
                 # number of traces per index record
                 max_workers=400,

--- a/src/tempo_cluster.py
+++ b/src/tempo_cluster.py
@@ -156,7 +156,7 @@ if PYDANTIC_IS_V1:
             if databag is None:
                 databag = {}
 
-            for key, value in self.dict(by_alias=True, exclude_none=True).items():  # type: ignore
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore
                 databag[key] = json.dumps(value)
 
             return databag
@@ -210,7 +210,7 @@ else:
             if databag is None:
                 databag = {}
 
-            dct = self.model_dump(mode="json", by_alias=True, exclude_none=True)  # type: ignore
+            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)  # type: ignore
             databag.update({k: json.dumps(v) for k, v in dct.items()})
             return databag
 

--- a/src/tempo_cluster.py
+++ b/src/tempo_cluster.py
@@ -121,13 +121,9 @@ if PYDANTIC_IS_V1:
             allow_population_by_field_name = True
             """Allow instantiating this class by field name (instead of forcing alias)."""
 
-        _NEST_UNDER = None
-
         @classmethod
         def load(cls, databag: MutableMapping):
             """Load this model from a Juju databag."""
-            if cls._NEST_UNDER:
-                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
 
             try:
                 data = {
@@ -160,11 +156,7 @@ if PYDANTIC_IS_V1:
             if databag is None:
                 databag = {}
 
-            if self._NEST_UNDER:
-                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
-                return databag
-
-            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore
+            for key, value in self.dict(by_alias=True, exclude_none=True).items():  # type: ignore
                 databag[key] = json.dumps(value)
 
             return databag
@@ -180,25 +172,19 @@ else:
             extra="ignore",
             # Allow instantiating this class by field name (instead of forcing alias).
             populate_by_name=True,
-            # Custom config key: whether to nest the whole datastructure (as json)
-            # under a field or spread it out at the toplevel.
-            _NEST_UNDER=None,
         )  # type: ignore
         """Pydantic config."""
 
         @classmethod
         def load(cls, databag: MutableMapping):
             """Load this model from a Juju databag."""
-            nest_under = cls.model_config.get("_NEST_UNDER")
-            if nest_under:
-                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
 
             try:
                 data = {
                     k: json.loads(v)
                     for k, v in databag.items()
                     # Don't attempt to parse model-external values
-                    if k in {(f.alias or n) for n, f in cls.__fields__.items()}  # type: ignore
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
                 }
             except json.JSONDecodeError as e:
                 msg = f"invalid databag contents: expecting json. {databag}"
@@ -223,16 +209,8 @@ else:
 
             if databag is None:
                 databag = {}
-            nest_under = self.model_config.get("_NEST_UNDER")
-            if nest_under:
-                databag[nest_under] = self.model_dump_json(  # type: ignore
-                    by_alias=True,
-                    # skip keys whose values are default
-                    exclude_defaults=True,
-                )
-                return databag
 
-            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)  # type: ignore
+            dct = self.model_dump(mode="json", by_alias=True, exclude_none=True)  # type: ignore
             databag.update({k: json.dumps(v) for k, v in dct.items()})
             return databag
 

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -19,9 +19,14 @@ logger = logging.getLogger(__name__)
 
 
 class ClientAuthTypeEnum(str, enum.Enum):
-    """client auth types"""
+    """Client auth types."""
 
+    # Possible values https://pkg.go.dev/crypto/tls#ClientAuthType
     VERIFY_CLIENT_CERT_IF_GIVEN = "VerifyClientCertIfGiven"
+    NO_CLIENT_CERT = "NoClientCert"
+    REQUEST_CLIENT_CERT = "RequestClientCert"
+    REQUIRE_ANY_CLIENT_CERT = "RequireAnyClientCert"
+    REQUIRE_AND_VERIFY_CLIENT_CERT = "RequireAndVerifyClientCert"
 
 
 class InvalidConfigurationError(Exception):

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -5,12 +5,10 @@
 
 import logging
 import re
-from dataclasses import asdict
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, model_validator, validator
-from pydantic.dataclasses import dataclass as pydantic_dataclass
+from pydantic import BaseModel, field_validator, model_validator
 
 S3_RELATION_NAME = "s3"
 BUCKET_NAME = "tempo"
@@ -24,37 +22,6 @@ class InvalidConfigurationError(Exception):
     pass
 
 
-class Memberlist(BaseModel):
-    """Memberlist schema."""
-
-    cluster_label: str
-    cluster_label_verification_disabled: bool = False
-    join_members: List[str]
-
-
-class Tsdb(BaseModel):
-    """Tsdb schema."""
-
-    dir: str = "/data/ingester"
-
-
-class BlocksStorage(BaseModel):
-    """Blocks storage schema."""
-
-    storage_prefix: str = "blocks"
-    tsdb: Tsdb
-
-
-class Limits(BaseModel):
-    """Limits schema."""
-
-    ingestion_rate: int = 0
-    ingestion_burst_size: int = 0
-    max_global_series_per_user: int = 0
-    ruler_max_rules_per_rule_group: int = 0
-    ruler_max_rule_groups_per_tenant: int = 0
-
-
 class Kvstore(BaseModel):
     """Kvstore schema."""
 
@@ -65,102 +32,174 @@ class Ring(BaseModel):
     """Ring schema."""
 
     kvstore: Kvstore
-    replication_factor: int = 3
+    replication_factor: int
+
+
+class Memberlist(BaseModel):
+    """Memberlist schema."""
+
+    abort_if_cluster_join_fails: bool
+    bind_port: int
+    join_members: List[str]
+    tls_enabled: Optional[bool] = False
+    tls_cert_path: Optional[str] = None
+    tls_key_path: Optional[str] = None
+    tls_ca_path: Optional[str] = None
+    tls_server_name: Optional[str] = None
+
+
+class ClientTLS(BaseModel):
+    """Client tls config schema."""
+
+    tls_enabled: bool
+    tls_cert_path: str
+    tls_key_path: str
+    tls_ca_path: str
+    tls_server_name: str
+
+
+class Client(BaseModel):
+    """Client schema."""
+
+    grpc_client_config: ClientTLS
 
 
 class Distributor(BaseModel):
     """Distributor schema."""
 
-    ring: Ring
+    ring: Optional[Ring] = None
+    receivers: Dict[str, Any]
 
 
 class Ingester(BaseModel):
     """Ingester schema."""
 
-    ring: Ring
+    trace_idle_period: str
+    max_block_bytes: int
+    max_block_duration: str
+    lifecycler: Optional[Ring] = None
 
 
-class Ruler(BaseModel):
-    """Ruler schema."""
+class FrontendWorker(BaseModel):
+    """FrontendWorker schema."""
 
-    rule_path: str = "/data/ruler"
-    alertmanager_url: Optional[str]
+    frontend_address: str
+    grpc_client_config: Optional[ClientTLS] = None
 
 
-class Alertmanager(BaseModel):
-    """Alertmanager schema."""
+class Querier(BaseModel):
+    """Querier schema."""
 
-    data_dir: str = "/data/alertmanager"
-    external_url: Optional[str]
+    frontend_worker: FrontendWorker
+
+
+class TLS(BaseModel):
+    """TLS configuration schema."""
+
+    cert_file: str
+    key_file: str
+    client_ca_file: str
+    client_auth_type: Optional[str] = "VerifyClientCertIfGiven"
 
 
 class Server(BaseModel):
     """Server schema."""
 
-    http_tls_config: Dict[str, Dict[str, str]]
-    grpc_tls_config: Dict[str, Dict[str, str]]
+    http_listen_port: int
+    grpc_listen_port: int
+    http_tls_config: Optional[TLS] = None
+    grpc_tls_config: Optional[TLS] = None
 
 
-class _S3ConfigData(BaseModel):
-    model_config = {"populate_by_name": True}
-    access_key_id: str = Field(alias="access-key")
+class Compaction(BaseModel):
+    """Compaction schema."""
+
+    compaction_window: str
+    max_compaction_objects: int
+    block_retention: str
+    compacted_block_retention: str
+    v2_out_buffer_bytes: int
+
+
+class Compactor(BaseModel):
+    """Compactor schema."""
+
+    ring: Optional[Ring] = None
+    compaction: Compaction
+
+
+class Pool(BaseModel):
+    """Pool schema."""
+
+    max_workers: int
+    queue_depth: int
+
+
+class Wal(BaseModel):
+    """Wal schema."""
+
+    path: str
+
+
+class S3(BaseModel):
+    """S3 config schema."""
+
+    bucket: str
+    access_key: str
     endpoint: str
-    secret_access_key: str = Field(alias="secret-key")
-    bucket_name: str = Field(alias="bucket")
-    region: str = ""
-    insecure: str = "false"
+    secret_key: str
+    insecure: Optional[bool] = False
 
     @model_validator(mode="before")  # pyright: ignore
     @classmethod
     def set_insecure(cls, data: Any) -> Any:
         if isinstance(data, dict) and data.get("endpoint", None):
-            data["insecure"] = "false" if data["endpoint"].startswith("https://") else "true"
+            data["insecure"] = False if data["endpoint"].startswith("https://") else True
         return data
 
-    @validator("endpoint")
+    @field_validator("endpoint")
     def remove_scheme(cls, v: str) -> str:
         """Remove the scheme from the s3 endpoint."""
-        return re.sub(rf"^{urlparse(v).scheme}://", "", v)
+        # remove scheme to avoid "Endpoint url cannot have fully qualified paths." on Tempo startup
+        return re.sub(
+            rf"^{urlparse(v).scheme}://",
+            "",
+            v,
+        )
 
 
-class _FilesystemStorageBackend(BaseModel):
-    dir: str
+class Block(BaseModel):
+    """Block schema."""
+
+    version: Optional[str]
 
 
-_StorageBackend = Union[_S3ConfigData, _FilesystemStorageBackend]
-_StorageKey = Union[Literal["filesystem"], Literal["s3"]]
+class TraceStorage(BaseModel):
+    """Trace Storage schema."""
+
+    wal: Wal
+    pool: Pool
+    backend: str
+    s3: S3
+    block: Block
 
 
-@pydantic_dataclass
-class CommonConfig:
-    """Common config schema."""
+class Storage(BaseModel):
+    """Storage schema."""
 
-    backend: _StorageKey
-    _StorageKey: _StorageBackend
-
-    def __post_init__(self):
-        """Verify the backend variable typing is correct."""
-        if not asdict(self).get("s3", "") and not asdict(self).get("s3", ""):
-            raise InvalidConfigurationError("Common storage configuration must specify a type!")
-        elif (asdict(self).get("filesystem", "") and not self.backend != "filesystem") or (
-            asdict(self).get("s3", "") and not self.backend != "s3"
-        ):
-            raise InvalidConfigurationError(
-                "Tempo `backend` type must include a configuration block which matches that type"
-            )
+    trace: TraceStorage
 
 
-class TempoBaseConfig(BaseModel):
-    """Base class for tempo config schema."""
+class Tempo(BaseModel):
+    """Tempo config schema."""
 
-    target: str
+    auth_enabled: bool
+    server: Server
+    distributor: Distributor
+    ingester: Ingester
     memberlist: Memberlist
-    multitenancy_enabled: bool = True
-    common: CommonConfig
-    limits: Limits
-    blocks_storage: Optional[BlocksStorage]
-    distributor: Optional[Distributor]
-    ingester: Optional[Ingester]
-    ruler: Optional[Ruler]
-    alertmanager: Optional[Alertmanager]
-    server: Optional[Server]
+    compactor: Compactor
+    querier: Querier
+    storage: Storage
+    ingester_client: Optional[Client] = None
+    metrics_generator_client: Optional[Client] = None

--- a/tests/integration/test_ingressed_tls.py
+++ b/tests/integration/test_ingressed_tls.py
@@ -1,3 +1,4 @@
+# TODO: uncomment and fix when the fully functional tempo cluster is ready (e.g: traces get ingested, can query for traces)
 # import asyncio
 # import json
 # import logging

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,3 +1,4 @@
+# TODO: uncomment and fix when the fully functional tempo cluster is ready (e.g: traces get ingested, can query for traces)
 # import asyncio
 # import json
 # import logging

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -1,3 +1,4 @@
+# TODO: uncomment and fix when the fully functional tempo cluster is ready (e.g: traces get ingested, can query for traces)
 # import asyncio
 # import json
 # import logging


### PR DESCRIPTION
## Issue
tempo configurations are in the form of raw dicts.

## Solution
Translate all currently used tempo config to pydantic models.

## Testing instructions
For coordinator to work and push tempo configuration to workers, it needs an s3 integration. To workaround the issue and not need an actual s3 instance, we can use Facade charm for mocking s3 interface.

### Deploy tempo k8s operator (used for validation)
```
juju deploy tempo-k8s tempo --resource tempo-image=grafana/tempo:2.4.0 --channel=latest/edge
```

### Deploy tempo coordinator
cwd to `tempo-coordinator-k8s-operator`

```
charmcraft pack
juju deploy ./tempo-coordinator-k8s_ubuntu-22.04-amd64.charm 
```

### Deploy Facade
cwd to `tempo-coordinator-k8s-operator`
```
juju deploy facade s3-facade --channel=latest/edge
juju integrate s3-facade:provide-s3 tempo-coordinator-k8s:s3
juju run s3-facade/0 update --params ./tests/manual/facades/s3.yaml
```

### Deploy tempo worker
cwd to `tempo-worker-k8s-operator`

```
git fetch
git checkout coordinator-integration
charmcraft pack
juju deploy ./tempo-worker-k8s_ubuntu-22.04-amd64.charm  tempo-worker --resource tempo-image=docker.io/ubuntu/tempo:2-22.04
```
### Integrate cluster
```
 juju integrate tempo-coordinator-k8s tempo-worker
```

### Validation

1- coordinator and worker should both be in active/idle
2- kubectl exec -it tempo-worker-0 -n <model> -c tempo -- cat /etc/tempo/tempo.yaml
3- kubectl exec -it tempo-0 -n <model> -c tempo -- cat /etc/tempo/tempo.yaml
4- Both config files should match apart from storage options, as s3 would be used in coordinator instead of local storage

### TLS Validation
Repeat above steps after ` juju integrate ssc tempo-coordinator-k8s`
