### PR TITLE
Fix coordination between Tempo's cluster members

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -493,7 +493,9 @@ class TempoCoordinatorCharm(CharmBase):
         # On every function call, we always publish everything to the databag; however, if there
         # are no changes, Juju will notice there's no delta and do nothing
         self.tempo_cluster.publish_data(
-            tempo_config=self.tempo.generate_config(self._requested_receivers(), self._s3_config),
+            tempo_config=self.tempo.generate_config(
+                self._requested_receivers(), self._s3_config, self.tempo_cluster.gather_addresses()
+            ),
             loki_endpoints=self.loki_endpoints_by_unit,
             # TODO tempo receiver for charm tracing
             **kwargs,

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -6,7 +6,7 @@
 import logging
 import socket
 from subprocess import CalledProcessError, getoutput
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from charms.tempo_k8s.v2.tracing import (
     ReceiverProtocol,
@@ -148,7 +148,7 @@ class Tempo:
         self,
         receivers: Sequence[ReceiverProtocol],
         s3_config: dict,
-        peers: Optional[List[str]] = None,
+        peers: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         """Generate the Tempo configuration.
 
@@ -249,7 +249,7 @@ class Tempo:
             )
         )
 
-    def _build_memberlist_config(self, peers: Optional[List[str]]) -> tempo_config.Memberlist:
+    def _build_memberlist_config(self, peers: Optional[Set[str]]) -> tempo_config.Memberlist:
         """Build memberlist config"""
         return tempo_config.Memberlist(
             abort_if_cluster_join_fails=False,

--- a/tests/scenario/test_config.py
+++ b/tests/scenario/test_config.py
@@ -1,0 +1,35 @@
+from scenario import State
+
+from charm import TempoCoordinatorCharm
+from tempo_cluster import TempoClusterRequirerUnitData
+
+
+def test_memberlist_multiple_members(context, all_worker, s3):
+    workers_no = 3
+    all_worker = all_worker.replace(
+        remote_units_data={
+            worker_idx: TempoClusterRequirerUnitData(
+                **{
+                    "address": f"worker-{worker_idx}.test.svc.cluster.local:7946",
+                    "juju_topology": {
+                        "model": "test",
+                        "unit": f"worker/{worker_idx}",
+                        "model_uuid": "1",
+                        "application": "worker",
+                        "charm_name": "TempoWorker",
+                    },
+                }
+            ).dump()
+            for worker_idx in range(workers_no)
+        },
+    )
+    state = State(leader=True, relations=[all_worker, s3])
+    with context.manager(all_worker.changed_event, state) as mgr:
+        charm: TempoCoordinatorCharm = mgr.charm
+        assert charm.tempo_cluster.gather_addresses() == set(
+            [
+                "worker-0.test.svc.cluster.local:7946",
+                "worker-1.test.svc.cluster.local:7946",
+                "worker-2.test.svc.cluster.local:7946",
+            ]
+        )


### PR DESCRIPTION
## Issue
when workers are scaled/distributed, each workload unit should carry the same data (Sync between the members' storage).

## Solution
Populate `memberlist` config option with all workers' resolvable cluster IPs/DNS names.

## Testing Instructions
### Deployment
Deploy a working Tempo cluster bundle in its default scaling monolithic mode (3 workers), as per https://github.com/canonical/tempo-bundle/pull/1

### Validation
Get each worker's unit IP address from:
 ```
juju status
 ```
Query traces from each of the 3 workloads
```
curl http://<WORKER_N>:3200/api/search
```
The set of traces returned from each workload should be identical.