### PR TITLE
Fix frontend_worker address in distributed mode

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -494,7 +494,10 @@ class TempoCoordinatorCharm(CharmBase):
         # are no changes, Juju will notice there's no delta and do nothing
         self.tempo_cluster.publish_data(
             tempo_config=self.tempo.generate_config(
-                self._requested_receivers(), self._s3_config, self.tempo_cluster.gather_addresses()
+                self._requested_receivers(),
+                self._s3_config,
+                self.tempo_cluster.gather_addresses_by_role(),
+                self.tempo_cluster.gather_addresses(),
             ),
             loki_endpoints=self.loki_endpoints_by_unit,
             # TODO tempo receiver for charm tracing

--- a/tests/scenario/test_tempo_clustered.py
+++ b/tests/scenario/test_tempo_clustered.py
@@ -21,7 +21,9 @@ def all_worker_with_initial_config(all_worker: Relation, s3_config):
     container.exists = lambda path: (
         False if path in [Tempo.tls_cert_path, Tempo.tls_key_path, Tempo.tls_ca_path] else True
     )
-    initial_config = Tempo(container).generate_config(["otlp_http"], s3_config)
+    initial_config = Tempo(container).generate_config(
+        ["otlp_http"], s3_config, {"all": "localhost"}
+    )
     new_local_app_data = TempoClusterProviderAppData(
         tempo_config=initial_config,
         loki_endpoints={},
@@ -111,5 +113,7 @@ def test_tempo_restart_on_ingress_v2_changed(
     # THEN
     # Tempo pushes a new config to the all_worker
     new_config = get_tempo_config(state_out)
-    expected_config = Tempo().generate_config(["otlp_http", requested_protocol], s3_config)
+    expected_config = Tempo().generate_config(
+        ["otlp_http", requested_protocol], s3_config, {"all": "localhost"}
+    )
     assert new_config == expected_config


### PR DESCRIPTION
## Issue
Currently, `frontend_address` is set to `localhost`. That won't work in distributed mode, as query-frontend will be in a different unit.

## Solution
If a worker is taking a role of 'query-frontend', replace `localhost` with the address of that workload.

## Testing Instructions
### Deployment
Deploy a working Tempo cluster bundle in its minimal microservices mode, as per https://github.com/canonical/tempo-bundle/pull/1

### Validation
Get coordinator's unit IP address from:
 ```
juju status
 ```
Query traces from the coordinator
```
curl http://<IP>:3200/api/search
```
The query should return back some traces instead of hanging.