### PR TITLE
Update TempoRolesConfig for cos-lib coordinator compatibility

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -20,14 +20,14 @@ from charms.tempo_k8s.v2.tracing import (
     receiver_protocol_to_transport_protocol,
 )
 from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
-from cosl.coordinated_workers.coordinator import Coordinator
+from cosl.coordinated_workers.coordinator import Coordinator, ClusterRolesConfig
 from cosl.coordinated_workers.nginx import CA_CERT_PATH, CERT_PATH, KEY_PATH
 from ops.charm import CharmBase, RelationEvent
 from ops.main import main
 
 from nginx_config import NginxConfig
 from tempo import Tempo
-from tempo_config import TempoRolesConfig
+from tempo_config import TEMPO_ROLES_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 @trace_charm(
     tracing_endpoint="tempo_otlp_http_endpoint",
     server_cert="server_ca_cert",
-    extra_types=(Tempo, TracingEndpointProvider, Coordinator, TempoRolesConfig),
+    extra_types=(Tempo, TracingEndpointProvider, Coordinator, ClusterRolesConfig),
 )
 class TempoCoordinatorCharm(CharmBase):
     """Charmed Operator for Tempo; a distributed tracing backend."""
@@ -49,7 +49,7 @@ class TempoCoordinatorCharm(CharmBase):
         self.unit.set_ports(*self.tempo.all_ports.values())
         self.coordinator = Coordinator(
             charm=self,
-            roles_config=TempoRolesConfig(),
+            roles_config=TEMPO_ROLES_CONFIG,
             s3_bucket_name=Tempo.s3_bucket_name,
             external_url=self._external_url,
             worker_metrics_port=self.tempo.tempo_http_server_port,

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -2,14 +2,15 @@
 # See LICENSE file for licensing details.
 
 """Helper module for interacting with the Tempo configuration."""
+
 import enum
 import logging
 import re
 from enum import Enum, unique
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
-
+from cosl.coordinated_workers.coordinator import ClusterRolesConfig
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
@@ -80,14 +81,13 @@ Helm chart configurations.
 https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/
 """
 
-
-class TempoRolesConfig:
-    """Define the configuration for Tempo roles."""
-
-    roles: Iterable[str] = {role for role in TempoRole}
-    meta_roles: Mapping[str, Iterable[str]] = META_ROLES
-    minimal_deployment: Iterable[str] = MINIMAL_DEPLOYMENT
-    recommended_deployment: Dict[str, int] = RECOMMENDED_DEPLOYMENT
+TEMPO_ROLES_CONFIG = ClusterRolesConfig(
+    roles={role for role in TempoRole},
+    meta_roles=META_ROLES,
+    minimal_deployment=MINIMAL_DEPLOYMENT,
+    recommended_deployment=RECOMMENDED_DEPLOYMENT,
+)
+"""Define the configuration for Tempo roles."""
 
 
 class ClientAuthTypeEnum(str, enum.Enum):

--- a/tests/unit/test_coherence.py
+++ b/tests/unit/test_coherence.py
@@ -7,7 +7,7 @@ from tempo_config import (
     MINIMAL_DEPLOYMENT,
     RECOMMENDED_DEPLOYMENT,
     TempoRole,
-    TempoRolesConfig,
+    TEMPO_ROLES_CONFIG,
 )
 
 
@@ -29,7 +29,7 @@ def test_coherent(mock_coordinator, roles, expected):
     cluster_mock.gather_roles = MagicMock(return_value=roles)
     mc.cluster = cluster_mock
     mc._is_coherent = None
-    mc.roles_config = TempoRolesConfig()
+    mc.roles_config = TEMPO_ROLES_CONFIG
 
     assert mc.is_coherent is expected
 
@@ -51,6 +51,6 @@ def test_recommended(mock_coordinator, roles, expected):
     cluster_mock.gather_roles = MagicMock(return_value=roles)
     mc.cluster = cluster_mock
     mc._is_recommended = None
-    mc.roles_config = TempoRolesConfig()
+    mc.roles_config = TEMPO_ROLES_CONFIG
 
     assert mc.is_recommended is expected


### PR DESCRIPTION
# Summary
Coordinator ClusterRoleConfig class has changed and requires tempo-coordinator to instantiate the ClusterRoleConfig directly.

# Requirements Before Merge
Requires the following PR:
- [x] [cos-lib](https://github.com/canonical/cos-lib/pull/63)

# Note:
* [static-charm CI](https://github.com/canonical/tempo-coordinator-k8s-operator/actions/runs/10530625903/job/29180960333?pr=26) test will fail until the above PR is merged
* [unit CI](https://github.com/canonical/tempo-coordinator-k8s-operator/actions/runs/10530625903/job/29180959892?pr=26) test will fail until the above PR is merged
* [scenario CI](https://github.com/canonical/tempo-coordinator-k8s-operator/actions/runs/10530625903/job/29180959683?pr=26) test will fail until the above PR is merged