### PR TITLE
Remove s3 bucket name configuration from coordinator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ cryptography
 # lib/charms/tempo_k8s/v1/tracing.py
 pydantic>=2
 # lib/charms/prometheus_k8s/v0/prometheus_scrape.py
-cosl>=0.0.26
+cosl>=0.0.29

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,6 @@ class TempoCoordinatorCharm(CharmBase):
         self.coordinator = Coordinator(
             charm=self,
             roles_config=TEMPO_ROLES_CONFIG,
-            s3_bucket_name=Tempo.s3_bucket_name,
             external_url=self._external_url,
             worker_metrics_port=self.tempo.tempo_http_server_port,
             endpoints={

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -26,8 +26,6 @@ class Tempo:
     wal_path = "/etc/tempo/tempo_wal"
     metrics_generator_wal_path = "/etc/tempo/metrics_generator_wal"
 
-    s3_bucket_name = "tempo"
-
     memberlist_port = 7946
 
     server_ports: Dict[str, int] = {


### PR DESCRIPTION
Remove S3 bucket name from the coordinator. S3 connection info (e.g: bucket name) would be fetched from S3 Integrator's relation data, which would be configured from S3 Integrator's side manually using a [config option](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio-for-s3-testing/15211#heading--integrate-s3)

## Context
https://github.com/canonical/cos-lib/pull/72