### PR TITLE
trusted coordinator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ cryptography
 # lib/charms/tempo_k8s/v1/tracing.py
 pydantic>=2
 # lib/charms/prometheus_k8s/v0/prometheus_scrape.py
-cosl>=0.0.32
+cosl>=0.0.33

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -40,7 +40,9 @@ async def test_build_and_deploy(ops_test: OpsTest, tempo_charm: Path):
     }
 
     await asyncio.gather(
-        ops_test.model.deploy(tempo_charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.deploy(
+            tempo_charm, resources=resources, application_name=APP_NAME, trust=True
+        ),
         ops_test.model.deploy(
             tester_charm,
             resources=resources_tester,

--- a/tests/integration/tester-grpc/src/charm.py
+++ b/tests/integration/tester-grpc/src/charm.py
@@ -211,12 +211,13 @@ class TempoTesterGrpcCharm(CharmBase):
 
     def _update(self, _):
         """Event handler for all things."""
-        self.ensure_container_setup()
-
-        logger.info("running _update")
         if not self.container.can_connect():
             self.unit.status = WaitingStatus("waiting for container connectivity...")
             return
+
+        self.ensure_container_setup()
+
+        logger.info("running _update")
 
         # Wait for IP address. IP address is needed for forming tester clusters
         # and for related apps' config.

--- a/tests/integration/tester/src/charm.py
+++ b/tests/integration/tester/src/charm.py
@@ -207,12 +207,13 @@ class TempoTesterCharm(CharmBase):
 
     def _update(self, _):
         """Event handler for all things."""
-        self.ensure_container_setup()
-
-        logger.info("running _update")
         if not self.container.can_connect():
             self.unit.status = WaitingStatus("waiting for container connectivity...")
             return
+
+        self.ensure_container_setup()
+
+        logger.info("running _update")
 
         # Wait for IP address. IP address is needed for forming tester clusters
         # and for related apps' config.


### PR DESCRIPTION
new version of the coordinator requires trust. It was missing in a single integration test; added it.
This should unblock https://github.com/canonical/tempo-worker-k8s-operator/pull/29