### PR TITLE
Add K8s resource patch to interface test fixtures

### DIFF
--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -76,11 +76,13 @@ def cluster_tester(interface_tester: InterfaceTester):
         "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
         _namespace="test-namespace",
         _patch=lambda _: None,
+        is_ready=True,
     ):
         with patch.multiple(
                 "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
                 _namespace="test-namespace",
                 _patch=lambda _: None,
+                is_ready=True,
         ):
             with charm_tracing_disabled():
                 interface_tester.configure(

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -104,17 +104,24 @@ def tracing_tester(interface_tester: InterfaceTester):
         "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
         _namespace="test-namespace",
         _patch=lambda _: None,
+        is_ready=k8s_resource_patch_ready,
     ):
-        with charm_tracing_disabled():
-            interface_tester.configure(
-                charm_type=TempoCoordinatorCharm,
-                state_template=State(
-                    leader=True,
-                    containers=[nginx_container, nginx_prometheus_exporter_container],
-                    relations=[peers, s3_relation, cluster_relation],
-                ),
-            )
-            yield interface_tester
+        with patch.multiple(
+                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                is_ready=k8s_resource_patch_ready,
+        ):
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, s3_relation, cluster_relation],
+                    ),
+                )
+                yield interface_tester
 
 
 @pytest.fixture
@@ -123,14 +130,21 @@ def s3_tester(interface_tester: InterfaceTester):
         "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
         _namespace="test-namespace",
         _patch=lambda _: None,
+        is_ready=k8s_resource_patch_ready,
     ):
-        with charm_tracing_disabled():
-            interface_tester.configure(
-                charm_type=TempoCoordinatorCharm,
-                state_template=State(
-                    leader=True,
-                    containers=[nginx_container, nginx_prometheus_exporter_container],
-                    relations=[peers, cluster_relation],
-                ),
-            )
-            yield interface_tester
+        with patch.multiple(
+                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                is_ready=k8s_resource_patch_ready,
+        ):
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, cluster_relation],
+                    ),
+                )
+                yield interface_tester

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -77,16 +77,21 @@ def cluster_tester(interface_tester: InterfaceTester):
         _namespace="test-namespace",
         _patch=lambda _: None,
     ):
-        with charm_tracing_disabled():
-            interface_tester.configure(
-                charm_type=TempoCoordinatorCharm,
-                state_template=State(
-                    leader=True,
-                    containers=[nginx_container, nginx_prometheus_exporter_container],
-                    relations=[peers, s3_relation],
-                ),
-            )
-            yield interface_tester
+        with patch.multiple(
+                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+        ):
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, s3_relation],
+                    ),
+                )
+                yield interface_tester
 
 
 @pytest.fixture

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
@@ -63,6 +63,8 @@ cluster_relation = Relation(
 
 peers = PeerRelation("peers", peers_data={1: {}})
 
+k8s_resource_patch_ready = MagicMock(return_value=True)
+
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
 # this fixture is used by the test runner of charm-relation-interfaces to test tempo's compliance
@@ -76,13 +78,13 @@ def cluster_tester(interface_tester: InterfaceTester):
         "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
         _namespace="test-namespace",
         _patch=lambda _: None,
-        is_ready=True,
+        is_ready=k8s_resource_patch_ready,
     ):
         with patch.multiple(
                 "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
                 _namespace="test-namespace",
                 _patch=lambda _: None,
-                is_ready=True,
+                is_ready=k8s_resource_patch_ready,
         ):
             with charm_tracing_disabled():
                 interface_tester.configure(

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
@@ -81,10 +81,10 @@ def cluster_tester(interface_tester: InterfaceTester):
         is_ready=k8s_resource_patch_ready,
     ):
         with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                is_ready=k8s_resource_patch_ready,
+            "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda _: None,
+            is_ready=k8s_resource_patch_ready,
         ):
             with charm_tracing_disabled():
                 interface_tester.configure(
@@ -107,10 +107,10 @@ def tracing_tester(interface_tester: InterfaceTester):
         is_ready=k8s_resource_patch_ready,
     ):
         with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                is_ready=k8s_resource_patch_ready,
+            "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda _: None,
+            is_ready=k8s_resource_patch_ready,
         ):
             with charm_tracing_disabled():
                 interface_tester.configure(
@@ -133,10 +133,10 @@ def s3_tester(interface_tester: InterfaceTester):
         is_ready=k8s_resource_patch_ready,
     ):
         with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                is_ready=k8s_resource_patch_ready,
+            "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda _: None,
+            is_ready=k8s_resource_patch_ready,
         ):
             with charm_tracing_disabled():
                 interface_tester.configure(


### PR DESCRIPTION
## Issue
Fixtures in interface tests started failing after some of the latest changes to cos-lib introducing K8s resource patch to the coordinator.


## Solution
Add coordinator's patch to patched objects.


## Context
https://github.com/canonical/charm-relation-interfaces/pull/174


## Testing Instructions
In the context of `charm-relation-interfaces` repo, run:
```
tox -e run-interface-test-matrix -- --include tempo_cluster --repo https://github.com/mmkay/charm-relation-interfaces.git --branch k8s-patch-fix
tox -e run-interface-test-matrix -- --include tracing --repo https://github.com/mmkay/charm-relation-interfaces.git --branch k8s-patch-fix
```

## Release Notes
<!-- A digestable summary of the change in this PR -->