### PR TITLE
Create a terraform module for Tempo

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,11 +11,6 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
     secrets: inherit
 
-  # TODO move this to the centralized CI
-  terraform-lint:
-    name: Terraform lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
-      - run: terraform fmt -check -recursive -diff
+  terraform-checks:
+    name: Terraform
+    uses: canonical/observability/.github/workflows/terraform-quality-checks.yaml@OPENG-2685

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,4 +13,4 @@ jobs:
 
   terraform-checks:
     name: Terraform
-    uses: canonical/observability/.github/workflows/terraform-quality-checks.yaml@OPENG-2685
+    uses: canonical/observability/.github/workflows/terraform-quality-checks.yaml@main

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,3 +10,12 @@ jobs:
     name: PR
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
     secrets: inherit
+
+  # TODO move this to the centralized CI
+  terraform-lint:
+    name: Terraform lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform fmt -check -recursive -diff

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 *.egg-info/
 cos-tool-*
 src/prometheus_alert_rules/consolidated_rules/**
+.terraform*
+*.tfstate*

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ cryptography
 # lib/charms/tempo_k8s/v1/tracing.py
 pydantic>=2
 # lib/charms/prometheus_k8s/v0/prometheus_scrape.py
-cosl>=0.0.37
+cosl>=0.0.39

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,43 @@
+Terraform module for tempo-coordinator-k8s
+
+This is a Terraform module facilitating the deployment of tempo-coordinator-k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(any) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `revision`| number | Revision number of the charm name | False |
+| `units`| number | Number of units to deploy | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+TODO: Update Tempo HA Terraform module link 
+> [!NOTE]
+> This module is intended to be used only in conjunction with its counterpart, [Tempo worker module](https://github.com/canonical/tempo-worker-k8s-operator) and, when deployed in isolation, is not functional. 
+> For the Tempo HA solution module deployment, check [Tempo HA module](https://github.com/canonical/observability)
+
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+
+To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>"`
+

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,12 +13,12 @@ The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
 | - | - | - | - |
-| `app_name`| string | Application name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `config`| map(any) | Map of the charm configuration options | False |
-| `model_name`| string | Name of the model that the charm is deployed on | True |
-| `revision`| number | Revision number of the charm name | False |
-| `units`| number | Number of units to deploy | False |
+| `app_name`| string | Application name | tempo |
+| `channel`| string | Channel that the charm is deployed from | latest/stable |
+| `config`| map(any) | Map of the charm configuration options | {} |
+| `model_name`| string | Name of the model that the charm is deployed on |  |
+| `revision`| number | Revision number of the charm name |  |
+| `units`| number | Number of units to deploy | 1 |
 
 ### Outputs
 Upon applied, the module exports the following outputs:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -39,5 +39,5 @@ TODO: Update Tempo HA Terraform module link
 
 Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
 
-To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>"`
+To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -14,7 +14,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | tempo |
-| `channel`| string | Channel that the charm is deployed from | latest/stable |
+| `channel`| string | Channel that the charm is deployed from | latest/edge |
 | `config`| map(any) | Map of the charm configuration options | {} |
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `revision`| number | Revision number of the charm name |  |
@@ -31,7 +31,6 @@ Upon applied, the module exports the following outputs:
 
 ## Usage
 
-TODO: Update Tempo HA Terraform module link 
 > [!NOTE]
 > This module is intended to be used only in conjunction with its counterpart, [Tempo worker module](https://github.com/canonical/tempo-worker-k8s-operator) and, when deployed in isolation, is not functional. 
 > For the Tempo HA solution module deployment, check [Tempo HA module](https://github.com/canonical/observability)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+resource "juju_application" "tempo_coordinator" {
+
+  name = var.app_name
+  # Coordinator and worker must be in the same model
+  model     = var.model_name
+  trust     = true
+  units     = var.units
+  config    = var.config
+
+
+  charm {
+    name     = "tempo-coordinator-k8s"
+    channel  = var.channel
+    revision = var.revision
+  }
+
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,10 +2,10 @@ resource "juju_application" "tempo_coordinator" {
 
   name = var.app_name
   # Coordinator and worker must be in the same model
-  model     = var.model_name
-  trust     = true
-  units     = var.units
-  config    = var.config
+  model  = var.model_name
+  trust  = true
+  units  = var.units
+  config = var.config
 
 
   charm {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "app_name" {
+  value = juju_application.tempo_coordinator.name
+}
+
+output "requires" {
+  value = {
+    self_tracing      = "self-tracing",
+    s3                = "s3",
+    logging           = "logging",
+    ingress           = "ingress",
+    certificates      = "certificates",
+    send-remote-write = "send-remote-write",
+  }
+}
+
+output "provides" {
+  value = {
+    tempo_cluster     = "tempo-cluster",
+    grafana_dashboard = "grafana-dashboard",
+    grafana_source    = "grafana-source",
+    metrics_endpoint  = "metrics-endpoint",
+    tracing           = "tracing",
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default = "tempo
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "latest/edge"
+}
+
+
+variable "config" {
+  description = "Charm config options as in the ones we pass in juju config"
+  type        = map(any)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units"
+  type        = number
+  default     = 1
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,10 +4,11 @@ variable "app_name" {
   default     = "tempo"
 }
 
+#Defaulting to latest/edge instead of stable as its not yet released
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/stable"
+  default     = "latest/edge"
 }
 
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/edge"
+  default     = "latest/stable"
 }
 
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "app_name" {
   description = "Application name"
   type        = string
-  default = "tempo
+  default     = "tempo"
 }
 
 variable "channel" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}


### PR DESCRIPTION
Add a terraform module for Tempo coordinator. 

## Context
https://github.com/canonical/mimir-worker-k8s-operator/pull/74
https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit

## TODO
- Automated tests will be part of a split task

## Testing Considerations
Install terraform on your machine
`cd terraform/ && terrform init && terraform apply` 