### PR TITLE
Add `S3` config TLS options

### DIFF
--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -257,6 +257,11 @@ class S3(BaseModel):
     endpoint: str
     secret_access_key: str = Field(alias="secret_key")
     insecure: bool = False
+    # cfr: https://grafana.com/docs/tempo/latest/configuration/#storage
+    tls_cert_path: Optional[str] = None
+    tls_ca_path: Optional[str] = None
+    tls_key_path: Optional[str] = None
+    tls_server_name: Optional[str] = None
 
     @model_validator(mode="before")  # pyright: ignore
     @classmethod


### PR DESCRIPTION
~## Issue~
~A juju hook can trigger a Tempo configuration change in `tempo_cluster` relation data and cause the worker to restart simply because the list ordering changed from one event to another.~

~## Solution~
~Sort the list before returning the config~

~## Drive-by~
~Add `tls_ca_path` config option~

Changing scope as fix as pushed in https://github.com/canonical/cos-lib/pull/86 and https://github.com/canonical/tempo-coordinator-k8s-operator/pull/50

## Issue
Add `tls_xx_path` config options to tempo configuration.

## Context
https://github.com/canonical/cos-lib/pull/84