### PR TITLE
Fix type hint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ cryptography
 # lib/charms/tempo_k8s/v1/tracing.py
 pydantic>=2
 # lib/charms/prometheus_k8s/v0/prometheus_scrape.py
-cosl>=0.0.33
+cosl>=0.0.36

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,6 +57,8 @@ class TempoCoordinatorCharm(CharmBase):
         # set the open ports for this unit
         self.unit.set_ports(*self.tempo.all_ports.values())
 
+        self.tracing = TracingEndpointProvider(self, external_url=self._external_url)
+
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
 
         self.coordinator = Coordinator(
@@ -93,8 +95,6 @@ class TempoCoordinatorCharm(CharmBase):
                 self.ingress.on.ready,
             ],
         )
-
-        self.tracing = TracingEndpointProvider(self, external_url=self._external_url)
 
         # refuse to handle any other event as we can't possibly know what to do.
         if not self.coordinator.can_handle_events:

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -223,7 +223,9 @@ class Tempo:
             )
         )
 
-    def _build_memberlist_config(self, peers: Optional[Set[str]]) -> tempo_config.Memberlist:
+    def _build_memberlist_config(
+        self, peers: Optional[Tuple[str, ...]]
+    ) -> tempo_config.Memberlist:
         """Build memberlist config"""
         return tempo_config.Memberlist(
             abort_if_cluster_join_fails=False,

--- a/tests/scenario/test_config.py
+++ b/tests/scenario/test_config.py
@@ -36,7 +36,7 @@ def test_memberlist_multiple_members(
     )
     with context(context.on.relation_changed(all_worker), state) as mgr:
         charm: TempoCoordinatorCharm = mgr.charm
-        assert charm.coordinator.cluster.gather_addresses() == set(
+        assert charm.coordinator.cluster.gather_addresses() == tuple(
             [
                 "worker-0.test.svc.cluster.local:7946",
                 "worker-1.test.svc.cluster.local:7946",


### PR DESCRIPTION
Change type hint from `Set[str]` to `Tuple[str, ...]`

## Context
https://github.com/canonical/cos-lib/pull/86

## Drive-by
Re-order `self.tracing=...` to be before `self.coordinator=...` to prevent a certain race condition where `self.tracing` is accessed inside coordinator code before `self.tracing` is declared. 