### PR TITLE
Fetch `internal_url` from charm instead of from shared coordinator

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -346,7 +346,7 @@ class TempoCoordinatorCharm(CharmBase):
             )
         else:
             url = (
-                self.coordinator.hostname
+                self.hostname
                 if protocol_type == TransportProtocolType.grpc
                 else self._internal_url
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -348,7 +348,7 @@ class TempoCoordinatorCharm(CharmBase):
             url = (
                 self.coordinator.hostname
                 if protocol_type == TransportProtocolType.grpc
-                else self.coordinator._internal_url
+                else self._internal_url
             )
 
         return f"{url}:{receiver_port}"

--- a/tests/scenario/test_tls.py
+++ b/tests/scenario/test_tls.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 import pytest
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
 from charms.tempo_k8s.v2.tracing import TracingProviderAppData, TracingRequirerAppData
-from cosl.coordinated_workers.coordinator import Coordinator
 from scenario import Relation, Secret, State
+
+from charm import TempoCoordinatorCharm
 
 
 @pytest.fixture
@@ -38,7 +39,9 @@ def update_relations_tls_and_verify(
     tracing,
 ):
     state = replace(base_state, relations=relations)
-    with charm_tracing_disabled(), patch.object(Coordinator, "tls_available", local_has_tls):
+    with charm_tracing_disabled(), patch.object(
+        TempoCoordinatorCharm, "are_certificates_on_disk", local_has_tls
+    ):
         out = context.run(context.on.relation_changed(tracing), state)
     tracing_provider_app_data = TracingProviderAppData.load(
         out.get_relations(tracing.endpoint)[0].local_app_data


### PR DESCRIPTION
## Issue
By adding a [common exit hook](https://github.com/canonical/cos-lib/pull/85) to the shared coordinator, some sort of a circular dependency happens as follows:

```
charm:self.coordinator = Coordinator(...) -> coordinator:self._reconcile() -> coordinator:self.update_cluster() -> coordinator:self._tracing_receivers_getter() -> charm:self.get_receiver_url(receiver) -> charm.self.coordinator._internal_url -> "AttributeError: 'TempoCoordinatorCharm' object has no attribute 'coordinator'"
```
## Solution
There is already an `_internal_url` property inside the charm that we can use instead of the coordinator's property.
The only difference between both properties is that the charm's check if certs are already on disk, which, in my opinion, is a better check than just checking if cert_handler has the certs or not.

Same with `self.coordinator.hostname`

## Context
https://github.com/canonical/cos-lib/pull/85

## Testing considerations
- Clone this branch
- In `requirements.txt`, change `cosl>=...` to `cosl@git+https://github.com/canonical/cos-lib@coord-reconcile`
- Run `tox -e scenario`
