### PR TITLE
Enable scaling `query-frontend`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,7 @@
 
 """Charmed Operator for Tempo; a lightweight object storage based tracing backend."""
 import logging
+import re
 import socket
 from pathlib import Path
 from subprocess import CalledProcessError, getoutput
@@ -49,6 +50,7 @@ class TempoCoordinatorCharm(CharmBase):
         self.tempo = Tempo(
             requested_receivers=self._requested_receivers,
             retention_period_hours=self._trace_retention_period_hours,
+            external_hostname=self._external_hostname,
         )
         # set alert_rules_path="", as we don't want to populate alert rules into the relation databag
         # we only need `self._remote_write.endpoints`
@@ -114,6 +116,11 @@ class TempoCoordinatorCharm(CharmBase):
     ######################
     # UTILITY PROPERTIES #
     ######################
+    @property
+    def _external_hostname(self) -> str:
+        """Return the external hostname."""
+        return re.sub(r"^https?:\/\/", "", self._external_url)
+
     @property
     def hostname(self) -> str:
         """Unit's hostname."""

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -152,7 +152,12 @@ class NginxConfig:
                     {
                         "directive": "grpc_pass" if grpc else "proxy_pass",
                         "args": [f"{protocol}://{upstream}"],
-                    }
+                    },
+                    # if a server is down, no need to wait for a long time to pass on the request to the next available server
+                    {
+                        "directive": "proxy_connect_timeout",
+                        "args": ["5s"],
+                    },
                 ],
             }
         ]

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -111,7 +111,7 @@ class Tempo:
             config.metrics_generator_client = tempo_config.Client(
                 grpc_client_config=tempo_config.ClientTLS(**tls_config)
             )
-            # use ingress hostname here, as the frontend worker would be pointning at the ingress url 
+            # use ingress hostname here, as the frontend worker would be pointning at the ingress url
             config.querier.frontend_worker.grpc_client_config = tempo_config.ClientTLS(
                 **{**tls_config, "tls_server_name": external_hostname},
             )

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -246,7 +246,7 @@ class Tempo:
             lifecycler=tempo_config.Lifecycler(
                 ring=tempo_config.Ring(
                     replication_factor=(
-                        3 if ingester_addresses and len(ingester_addresses) > 1 else 1
+                        3 if ingester_addresses and len(ingester_addresses) >= 3 else 1
                     )
                 ),
             ),

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -111,7 +111,7 @@ class Tempo:
             config.metrics_generator_client = tempo_config.Client(
                 grpc_client_config=tempo_config.ClientTLS(**tls_config)
             )
-            # use ingress hostname here, as the frontend worker would be pointning at the ingress url
+            # use ingress hostname here, as the query-frontend worker would be pointing at the ingress url
             config.querier.frontend_worker.grpc_client_config = tempo_config.ClientTLS(
                 **{**tls_config, "tls_server_name": self._external_hostname},
             )

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -127,8 +127,14 @@ class Kvstore(BaseModel):
 class Ring(BaseModel):
     """Ring schema."""
 
-    kvstore: Kvstore
+    kvstore: Optional[Kvstore] = None
     replication_factor: int
+
+
+class Lifecycler(BaseModel):
+    """Lifecycler schema."""
+
+    ring: Ring
 
 
 class Memberlist(BaseModel):
@@ -173,7 +179,7 @@ class Ingester(BaseModel):
     trace_idle_period: str
     max_block_bytes: int
     max_block_duration: str
-    lifecycler: Optional[Ring] = None
+    lifecycler: Lifecycler
 
 
 class FrontendWorker(BaseModel):

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -103,19 +103,6 @@ async def test_relate_ssc(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_relate_ssc(ops_test: OpsTest):
-    await ops_test.model.integrate(APP_NAME + ":certificates", SSC_APP_NAME + ":certificates")
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(
-            apps=[APP_NAME, SSC_APP_NAME, TRAEFIK_APP_NAME, WORKER_NAME],
-            status="active",
-            raise_on_blocked=True,
-            timeout=1000,
-        ),
-    )
-
-
-@pytest.mark.abort_on_fail
 async def test_push_tracegen_script_and_deps(ops_test: OpsTest):
     await ops_test.juju("scp", TRACEGEN_SCRIPT_PATH, f"{APP_NAME}/0:tracegen.py")
     await ops_test.juju(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -103,6 +103,19 @@ async def test_relate_ssc(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
+async def test_relate_ssc(ops_test: OpsTest):
+    await ops_test.model.integrate(APP_NAME + ":certificates", SSC_APP_NAME + ":certificates")
+    await asyncio.gather(
+        ops_test.model.wait_for_idle(
+            apps=[APP_NAME, SSC_APP_NAME, TRAEFIK_APP_NAME, WORKER_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        ),
+    )
+
+
+@pytest.mark.abort_on_fail
 async def test_push_tracegen_script_and_deps(ops_test: OpsTest):
     await ops_test.juju("scp", TRACEGEN_SCRIPT_PATH, f"{APP_NAME}/0:tracegen.py")
     await ops_test.juju(

--- a/tests/scenario/test_tempo_clustered.py
+++ b/tests/scenario/test_tempo_clustered.py
@@ -33,7 +33,6 @@ def coordinator_with_initial_config():
         "query-frontend": {"localhost"},
         "distributor": {"localhost"},
     }
-    new_coordinator_mock.return_value._external_url = socket.getfqdn()
 
     return new_coordinator_mock
 
@@ -41,7 +40,7 @@ def coordinator_with_initial_config():
 @pytest.fixture
 def all_worker_with_initial_config(all_worker: Relation, coordinator_with_initial_config):
 
-    initial_config = Tempo(lambda: ("otlp_http",), 42).config(
+    initial_config = Tempo(lambda: ("otlp_http",), 42, socket.getfqdn()).config(
         coordinator_with_initial_config.return_value
     )
 
@@ -158,7 +157,7 @@ def test_tempo_restart_on_ingress_v2_changed(
     # THEN
     # Tempo pushes a new config to the all_worker
     new_config = get_tempo_config(state_out)
-    expected_config = Tempo(lambda: ["otlp_http", requested_protocol], 720).config(
-        coordinator_with_initial_config.return_value
-    )
+    expected_config = Tempo(
+        lambda: ["otlp_http", requested_protocol], 720, socket.getfqdn()
+    ).config(coordinator_with_initial_config.return_value)
     assert new_config == expected_config

--- a/tests/scenario/test_tempo_clustered.py
+++ b/tests/scenario/test_tempo_clustered.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import socket
 from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
@@ -32,6 +33,7 @@ def coordinator_with_initial_config():
         "query-frontend": {"localhost"},
         "distributor": {"localhost"},
     }
+    new_coordinator_mock.return_value._external_url = socket.getfqdn()
 
     return new_coordinator_mock
 

--- a/tests/unit/test_tempo.py
+++ b/tests/unit/test_tempo.py
@@ -83,7 +83,8 @@ from tempo import Tempo
 )
 def test_tempo_distributor_config(protocols, use_tls, expected_config):
     assert (
-        Tempo(None, 720)._build_distributor_config(protocols, use_tls).receivers == expected_config
+        Tempo(None, 720, "hostname")._build_distributor_config(protocols, use_tls).receivers
+        == expected_config
     )
 
 
@@ -107,7 +108,7 @@ def test_tempo_distributor_config(protocols, use_tls, expected_config):
     ),
 )
 def test_tempo_memberlist_config(peers, expected_config):
-    assert Tempo(None, 720)._build_memberlist_config(peers) == expected_config
+    assert Tempo(None, 720, "hostname")._build_memberlist_config(peers) == expected_config
 
 
 @pytest.mark.parametrize(
@@ -129,6 +130,8 @@ def test_tempo_memberlist_config(peers, expected_config):
 )
 def test_tempo_ingester_config(addresses, expected_replication):
     assert (
-        Tempo(None, 720)._build_ingester_config(addresses).lifecycler.ring.replication_factor
+        Tempo(None, 720, "hostname")
+        ._build_ingester_config(addresses)
+        .lifecycler.ring.replication_factor
         == expected_replication
     )

--- a/tests/unit/test_tempo.py
+++ b/tests/unit/test_tempo.py
@@ -114,7 +114,7 @@ def test_tempo_memberlist_config(peers, expected_config):
     "addresses, expected_replication",
     (
         (
-            {"querier": {"addr1"}, "ingester": {"addr1", "addr2"}},
+            {"querier": {"addr1"}, "ingester": {"addr1", "addr2", "addr3"}},
             3,
         ),
         (

--- a/tests/unit/test_tempo.py
+++ b/tests/unit/test_tempo.py
@@ -108,3 +108,27 @@ def test_tempo_distributor_config(protocols, use_tls, expected_config):
 )
 def test_tempo_memberlist_config(peers, expected_config):
     assert Tempo(None, 720)._build_memberlist_config(peers) == expected_config
+
+
+@pytest.mark.parametrize(
+    "addresses, expected_replication",
+    (
+        (
+            {"querier": {"addr1"}, "ingester": {"addr1", "addr2"}},
+            3,
+        ),
+        (
+            {"querier": {"addr1"}},
+            1,
+        ),
+        (
+            {"ingester": {"addr2"}, "querier": {"addr1"}},
+            1,
+        ),
+    ),
+)
+def test_tempo_ingester_config(addresses, expected_replication):
+    assert (
+        Tempo(None, 720)._build_ingester_config(addresses).lifecycler.ring.replication_factor
+        == expected_replication
+    )


### PR DESCRIPTION
## Issue
Currently, in distributed mode, a Tempo worker with a dedicated role of `querier` can only point to [1 address](https://grafana.com/docs/tempo/latest/configuration/#querier) pointing to a `query-frontend` worker.  Multiple `querier`s can point to the same `query-frontend` instance. However, a Tempo worker with a dedicated role of `query-frontend` will not start unless its being pointed at by at least 1 instance of `querier`. 

In our recommended HA deployment, each worker role should have at least 3 replicas/units to be resilient against when a node becomes unavailable/down. So, what happens is that we scale `query-frontend` to 3 units, 2 of them will fail to start, as all units of the `queriers` point only to 1 unit of `query-frontend`. 


## Solution
The most straight forward solution to that is to give the coordinator's `external_url` (ingress or fqdn) as the `frontend_address`. The coordinator's `nginx` will intercept the request and loadbalance it across all instances of the `query-frontend`. This will enable us to scale `query-frontend` units as we like.

## Drive-bys
- Update cosl
- Make ingester replication-factor to 3 to ensure that the Tempo cluster can still be functional if one of the ingesters is down
- Add `proxy_connect_timeout=5s` instead of the default of `60s` to nginx config.
- Reorder `test_tls.py` to integrate with `ssc` after cluster is settled down (possible bug).

## Testing Considerations
### Short path (Test that `query-frontend` can be scaled)
1. [Deploy Tempo HA in distributed mode
](https://discourse.charmhub.io/t/topic/15489#heading--add-dedicated-workers)
2. `juju add-unit tempo-query-frontend -n 2`
3. All units go at `active/idle` instead of being stuck at restarting

### Longer path (Test resiliency when node is down)
1. Bootstrap LXD controller
2. Deploy [charmed microk8s](https://charmhub.io/microk8s/docs/how-to-cluster) with 3 units (3 nodes) 
3. Deploy Tempo HA with anti-affinity
```
bundle: kubernetes
applications:
  minio:
    charm: minio
    channel: latest/edge
    revision: 376
    base: ubuntu@20.04/stable
    resources:
      oci-image: 545
    scale: 1
    options:
      access-key: accesskey
      secret-key: mysoverysecretkey
    constraints: arch=amd64
    storage:
      minio-data: kubernetes,1,10240M
    trust: true
  s3-integrator:
    charm: s3-integrator
    channel: latest/edge
    revision: 59
    scale: 1
    options:
      bucket: tempo
      endpoint: minio-0.minio-endpoints.test.svc.cluster.local:9000
    constraints: arch=amd64
  tempo:
    charm: local:tempo-coordinator-k8s-9
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-compactor:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 3
    options:
      role-all: false
      role-compactor: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo-compactor,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-distributor:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 3
    options:
      role-all: false
      role-distributor: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo-distributor,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-ingester:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 3
    options:
      role-all: false
      role-ingester: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo-ingester,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-metrics-generator:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 3
    options:
      role-all: false
      role-metrics-generator: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo-metrics-generator,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-querier:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 3
    options:
      role-all: false
      role-querier: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo-querier,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-query-frontend:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 3
    options:
      role-all: false
      role-query-frontend: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo-query-frontend,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
    trust: true
relations:
- - tempo:tempo-cluster
  - tempo-ingester:tempo-cluster
- - tempo:tempo-cluster
  - tempo-distributor:tempo-cluster
- - tempo:tempo-cluster
  - tempo-metrics-generator:tempo-cluster
- - tempo:tempo-cluster
  - tempo-compactor:tempo-cluster
- - tempo:tempo-cluster
  - tempo-querier:tempo-cluster
- - tempo:tempo-cluster
  - tempo-query-frontend:tempo-cluster
- - tempo:s3
  - s3-integrator:s3-credentials
```
4. ssh into the microk8s node (lxd machine) where `tempo` coordinator and `minio` are not deployed 
5. `sudo microk8s leave` to make node go down
6. Wait until units in that node go in `agent lost` state.
7. Get `tempo` IP
8. `curl <tempo_ip>:3200/api/search` should be successful and return new traces.
