### PR TITLE
Configure Tempo's internal workload traces

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -198,6 +198,8 @@ class TempoCoordinatorCharm(CharmBase):
         enabled_receivers = set()
         # otlp_http is needed by charm_tracing
         enabled_receivers.add("otlp_http")
+        # jaeger_thrift_http is needed by Tempo's internal workload traces
+        enabled_receivers.add("jaeger_thrift_http")
         enabled_receivers.update(
             [
                 receiver

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -342,6 +342,7 @@ class TempoConfig(BaseModel):
     """Tempo config schema."""
 
     auth_enabled: bool
+    use_otel_tracer: bool = True
     server: Server
     distributor: Distributor
     ingester: Ingester

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -108,7 +108,7 @@ async def test_push_tracegen_script_and_deps(ops_test: OpsTest):
     await ops_test.juju(
         "ssh",
         f"{APP_NAME}/0",
-        "python3 -m pip install opentelemetry-exporter-otlp-proto-grpc opentelemetry-exporter-otlp-proto-http"
+        "python3 -m pip install protobuf==3.20.* opentelemetry-exporter-otlp-proto-grpc opentelemetry-exporter-otlp-proto-http"
         + " opentelemetry-exporter-zipkin opentelemetry-exporter-jaeger",
     )
 

--- a/tests/scenario/test_ingressed_tracing.py
+++ b/tests/scenario/test_ingressed_tracing.py
@@ -1,14 +1,10 @@
+import json
 from dataclasses import replace
 from unittest.mock import patch
 
 import pytest
 import yaml
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
-from charms.tempo_coordinator_k8s.v0.tracing import (
-    ProtocolType,
-    Receiver,
-    TracingProviderAppData,
-)
 from scenario import Relation, State
 
 
@@ -31,19 +27,23 @@ def test_external_url_present(context, base_state, s3, all_worker):
 
     # THEN external_url is present in tracing relation databag
     tracing_out = out.get_relations(tracing.endpoint)[0]
-    expected_data = TracingProviderAppData(
-        receivers=[
-            Receiver(
-                protocol=ProtocolType(name="otlp_http", type="http"),
-                url="http://1.2.3.4:4318",
-            ),
-            Receiver(
-                protocol=ProtocolType(name="jaeger_thrift_http", type="http"),
-                url="http://1.2.3.4:14268",
-            ),
-        ]
-    ).dump()
-    assert tracing_out.local_app_data == expected_data
+    expected_data = [
+        {
+            "protocol": {"name": "jaeger_thrift_http", "type": "http"},
+            "url": "http://1.2.3.4:14268",
+        },
+        {
+            "protocol": {"name": "otlp_http", "type": "http"},
+            "url": "http://1.2.3.4:4318",
+        },
+    ]
+    assert (
+        sorted(
+            json.loads(tracing_out.local_app_data["receivers"]),
+            key=lambda x: x["protocol"]["name"],
+        )
+        == expected_data
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/scenario/test_ingressed_tracing.py
+++ b/tests/scenario/test_ingressed_tracing.py
@@ -4,6 +4,11 @@ from unittest.mock import patch
 import pytest
 import yaml
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from charms.tempo_coordinator_k8s.v0.tracing import (
+    ProtocolType,
+    Receiver,
+    TracingProviderAppData,
+)
 from scenario import Relation, State
 
 
@@ -26,9 +31,19 @@ def test_external_url_present(context, base_state, s3, all_worker):
 
     # THEN external_url is present in tracing relation databag
     tracing_out = out.get_relations(tracing.endpoint)[0]
-    assert tracing_out.local_app_data == {
-        "receivers": '[{"protocol": {"name": "otlp_http", "type": "http"}, "url": "http://1.2.3.4:4318"}]',
-    }
+    expected_data = TracingProviderAppData(
+        receivers=[
+            Receiver(
+                protocol=ProtocolType(name="otlp_http", type="http"),
+                url="http://1.2.3.4:4318",
+            ),
+            Receiver(
+                protocol=ProtocolType(name="jaeger_thrift_http", type="http"),
+                url="http://1.2.3.4:14268",
+            ),
+        ]
+    ).dump()
+    assert tracing_out.local_app_data == expected_data
 
 
 @pytest.mark.parametrize(

--- a/tests/scenario/test_tempo_clustered.py
+++ b/tests/scenario/test_tempo_clustered.py
@@ -156,7 +156,7 @@ def test_tempo_restart_on_ingress_v2_changed(
     # THEN
     # Tempo pushes a new config to the all_worker
     new_config = get_tempo_config(state_out)
-    expected_config = Tempo(lambda: ["otlp_http", requested_protocol], 720).config(
-        coordinator_with_initial_config.return_value
-    )
+    expected_config = Tempo(
+        lambda: ["otlp_http", requested_protocol, "jaeger_thrift_http"], 720
+    ).config(coordinator_with_initial_config.return_value)
     assert new_config == expected_config

--- a/tests/scenario/test_tls.py
+++ b/tests/scenario/test_tls.py
@@ -49,7 +49,9 @@ def update_relations_tls_and_verify(
     tracing_provider_app_data = TracingProviderAppData.load(
         out.get_relations(tracing.endpoint)[0].local_app_data
     )
-    actual_url = tracing_provider_app_data.receivers[0].url
+    for receiver in tracing_provider_app_data.receivers:
+        if receiver.protocol.name == "otlp_http":
+            actual_url = receiver.url
     expected_url = f"{remote_scheme if has_ingress else local_scheme}://{socket.getfqdn() if not has_ingress else 'foo.com.org'}:4318"
     assert actual_url == expected_url
     return out

--- a/tests/scenario/test_tracing_provider.py
+++ b/tests/scenario/test_tracing_provider.py
@@ -1,5 +1,5 @@
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
-from charms.tempo_coordinator_k8s.v0.tracing import ProtocolType, TracingProviderAppData
+from charms.tempo_coordinator_k8s.v0.tracing import TracingProviderAppData
 from scenario import Relation, State
 
 
@@ -32,11 +32,14 @@ def test_receivers_removed_on_relation_broken(
     with charm_tracing_disabled():
         with context(context.on.relation_broken(tracing_grpc), state) as mgr:
             charm = mgr.charm
-            assert charm._requested_receivers() == ("otlp_http",)
+            assert set(charm._requested_receivers()) == {"otlp_http", "jaeger_thrift_http"}
             state_out = mgr.run()
 
     r_out = [r for r in state_out.relations if r.id == tracing_http.id][0]
     # "otlp_grpc" is gone from the databag
-    assert [r.protocol for r in TracingProviderAppData.load(r_out.local_app_data).receivers] == [
-        ProtocolType(name="otlp_http", type="http")
+    assert sorted(
+        [r.protocol.name for r in TracingProviderAppData.load(r_out.local_app_data).receivers]
+    ) == [
+        "jaeger_thrift_http",
+        "otlp_http",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,8 @@ deps =
     opentelemetry-exporter-otlp-proto-grpc
     opentelemetry-exporter-zipkin
     opentelemetry-exporter-jaeger
+    # opentelemetry-exporter-jaeger complains about old generated protos
+    protobuf==3.20.*
 commands =
     pytest -v --tb native --log-cli-level=INFO {[vars]tst_path}integration -s {posargs}
 


### PR DESCRIPTION
## Issue
Enable sending Tempo's (workload) internal traces.

## Solution
- send config with `use_otel_tracer=True`.
- Add `jaeger_thrift_http` as an enabled protocol by default. (Future versions of Tempo would support `otlp`)

## Testing Instructions
1. Deploy Tempo HA solution with this [worker](https://github.com/canonical/tempo-worker-k8s-operator/pull/47)
2. Deploy grafana
3. integrate `tempo:grafana-source` with `grafana`
4. You'll find tempo's workload traces