### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,15 +4,18 @@ output "app_name" {
 
 output "endpoints" {
   value = {
+    # Requires
     certificates      = "certificates",
-    grafana_dashboard = "grafana-dashboard",
-    grafana_source    = "grafana-source",
     ingress           = "ingress",
     logging           = "logging",
-    metrics_endpoint  = "metrics-endpoint",
     s3                = "s3",
     self_tracing      = "self-tracing",
     send-remote-write = "send-remote-write",
+    
+    # Provides
+    grafana_dashboard = "grafana-dashboard",
+    grafana_source    = "grafana-source",
+    metrics_endpoint  = "metrics-endpoint",
     tempo_cluster     = "tempo-cluster",
     tracing           = "tracing",
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,7 +11,6 @@ output "endpoints" {
     s3                = "s3",
     self_tracing      = "self-tracing",
     send-remote-write = "send-remote-write",
-    
     # Provides
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,23 +2,18 @@ output "app_name" {
   value = juju_application.tempo_coordinator.name
 }
 
-output "requires" {
+output "endpoints" {
   value = {
-    self_tracing      = "self-tracing",
-    s3                = "s3",
-    logging           = "logging",
-    ingress           = "ingress",
     certificates      = "certificates",
-    send-remote-write = "send-remote-write",
-  }
-}
-
-output "provides" {
-  value = {
-    tempo_cluster     = "tempo-cluster",
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",
+    ingress           = "ingress",
+    logging           = "logging",
     metrics_endpoint  = "metrics-endpoint",
+    s3                = "s3",
+    self_tracing      = "self-tracing",
+    send-remote-write = "send-remote-write",
+    tempo_cluster     = "tempo-cluster",
     tracing           = "tracing",
   }
 }


### PR DESCRIPTION
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Coordinating PR
- https://github.com/canonical/observability/pull/226