### PR TITLE
Enable service graph processor

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -530,7 +530,7 @@ class TempoCoordinatorCharm(CharmBase):
         self._update_grafana_source()
 
     def _get_grafana_source_uids(self) -> Dict[str, Dict[str, str]]:
-        """Helper method to retrieve grafana source UIDs from remote databags using raw relations.
+        """Helper method to retrieve the databags of any grafana-source relations.
 
         Duplicate implementation of GrafanaSourceProvider.get_source_uids() to use in the
         situation where we want to access relation data when the GrafanaSourceProvider object
@@ -555,9 +555,9 @@ class TempoCoordinatorCharm(CharmBase):
     def _build_service_graph_config(self) -> Dict[str, Any]:
         """Build the service graph config based on matching datasource UIDs.
 
-        To enable service graphs, we need the datasource UID of the prometheus/mimir instance where:
-        1- Tempo is connected to over "send-remote-write" relation.
-        2- It is also connected, as a datasource, to the same grafana instance(s) Tempo is connected to.
+        To enable service graphs, we need the datasource UID of any prometheus/mimir instance such that:
+        1- Tempo is connected to it over "send-remote-write".
+        2- It is also connected, over `grafana_datasource`, to at least one of the grafana instance(s) that Tempo is connected to.
 
         If there are multiple datasources that fit this description, we can assume that they are all
         equivalent and we can use any of them.
@@ -601,6 +601,7 @@ class TempoCoordinatorCharm(CharmBase):
         ]
 
         if not matching_datasources:
+            # take good care of logging exactly why this happening, as the logic is quite complex and debugging this will be hell
             msg = "service graph disabled."
             missing_rels = []
             if not remote_write_apps:

--- a/src/charm.py
+++ b/src/charm.py
@@ -446,8 +446,8 @@ class TempoCoordinatorCharm(CharmBase):
         return {"cpu": "50m", "memory": "100Mi"}
 
     def remote_write_endpoints(self):
-        """Return remote-write endpoints."""
-        return self._remote_write.endpoints
+        """Return a sorted list of remote-write endpoints."""
+        return sorted(self._remote_write.endpoints, key=lambda x: x["url"])
 
     def _update_source_exchange(self) -> None:
         """Update the grafana-datasource-exchange relations with what we receive from grafana-source."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,12 +3,13 @@
 # See LICENSE file for licensing details.
 
 """Charmed Operator for Tempo; a lightweight object storage based tracing backend."""
+import json
 import logging
 import re
 import socket
 from pathlib import Path
 from subprocess import CalledProcessError, getoutput
-from typing import Dict, List, Optional, Set, Tuple, cast, get_args
+from typing import Any, Dict, List, Optional, Set, Tuple, cast, get_args
 
 import ops
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
@@ -25,8 +26,8 @@ from charms.tempo_coordinator_k8s.v0.tracing import (
 from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
 from cosl.coordinated_workers.coordinator import ClusterRolesConfig, Coordinator
 from cosl.coordinated_workers.nginx import CA_CERT_PATH, CERT_PATH, KEY_PATH
-from cosl.interfaces.datasource_exchange import DatasourceDict
-from cosl.interfaces.utils import DatabagModel
+from cosl.interfaces.datasource_exchange import DatasourceDict, DSExchangeAppData
+from cosl.interfaces.utils import DatabagModel, DataValidationError
 from ops import CollectStatusEvent
 from ops.charm import CharmBase
 
@@ -36,6 +37,7 @@ from tempo_config import TEMPO_ROLES_CONFIG
 
 logger = logging.getLogger(__name__)
 PEERS_RELATION_ENDPOINT_NAME = "peers"
+PROMETHEUS_DS_TYPE = "prometheus"
 
 
 class TempoCoordinator(Coordinator):
@@ -132,6 +134,7 @@ class TempoCoordinatorCharm(CharmBase):
                 # or when ingress changes
                 self.ingress.on.ready,
             ],
+            extra_fields=self._grafana_source_extra_fields,
         )
 
         # peer
@@ -153,6 +156,25 @@ class TempoCoordinatorCharm(CharmBase):
     ######################
     # UTILITY PROPERTIES #
     ######################
+    @property
+    def _grafana_source_extra_fields(self) -> Dict[str, Any]:
+        """Extra fields needed for the grafana-source relation, like data correlation config."""
+        ## https://grafana.com/docs/tempo/latest/metrics-generator/service_graphs/enable-service-graphs/
+        # "httpMethod": "GET",
+        # "serviceMap": {
+        #     "datasourceUid": "juju_svcgraph_61e32e2f-50ac-40e7-8ee8-1b7297a3e47f_prometheus_0",
+        # },
+        # # https://community.grafana.com/t/how-to-jump-from-traces-to-logs/72477/3
+        # "tracesToLogs": {
+        #     "datasourceUid": "juju_svcgraph_61e32e2f-50ac-40e7-8ee8-1b7297a3e47f_loki_0"
+        # },
+        # "lokiSearch": {
+        #     "datasourceUid": "juju_svcgraph_61e32e2f-50ac-40e7-8ee8-1b7297a3e47f_loki_0"
+        # },
+
+        service_graph_config = self._build_service_graph_config()
+        return service_graph_config
+
     @property
     def peers(self):
         """Fetch the "peers" peer relation."""
@@ -493,6 +515,10 @@ class TempoCoordinatorCharm(CharmBase):
         # publish() already sorts the data for us, to prevent databag flapping and ensuing event storms
         self.coordinator.datasource_exchange.publish(datasources=raw_datasources)
 
+    def _update_grafana_source(self) -> None:
+        """Update grafana-source relations."""
+        self.grafana_source_provider.update_source(source_url=self._external_http_server_url)
+
     def _reconcile(self):
         # This method contains unconditional update logic, i.e. logic that should be executed
         # regardless of the event we are processing.
@@ -501,6 +527,113 @@ class TempoCoordinatorCharm(CharmBase):
         self._update_ingress_relation()
         self._update_tracing_relations()
         self._update_source_exchange()
+        self._update_grafana_source()
+
+    def _get_grafana_source_uids(self) -> Dict[str, Dict[str, str]]:
+        """Helper method to retrieve grafana source UIDs from remote databags using raw relations.
+
+        Duplicate implementation of GrafanaSourceProvider.get_source_uids() to use in the
+        situation where we want to access relation data when the GrafanaSourceProvider object
+        is not yet initialised.
+        """
+        uids = {}
+        for rel in self.model.relations.get("grafana-source", []):
+            if not rel:
+                continue
+            app_databag = rel.data[rel.app]
+            grafana_uid = app_databag.get("grafana_uid")
+            if not grafana_uid:
+                logger.warning(
+                    "remote end is using an old grafana_datasource interface: "
+                    "`grafana_uid` field not found."
+                )
+                continue
+
+            uids[grafana_uid] = json.loads(app_databag.get("datasource_uids", "{}"))
+        return uids
+
+    def _build_service_graph_config(self) -> Dict[str, Any]:
+        """Build the service graph config based on matching datasource UIDs.
+
+        To enable service graphs, we need the datasource UID of the prometheus/mimir instance where:
+        1- Tempo is connected to over "send-remote-write" relation.
+        2- It is also connected, as a datasource, to the same grafana instance(s) Tempo is connected to.
+
+        If there are multiple datasources that fit this description, we can assume that they are all
+        equivalent and we can use any of them.
+        """
+
+        dsx_relations = {
+            relation.app.name: relation
+            for relation in self.coordinator.datasource_exchange._relations
+        }
+
+        remote_write_apps = {
+            relation.app.name
+            for relation in self.model.relations["send-remote-write"]
+            if relation.app and relation.data
+        }
+
+        # the list of datasource exchange relations whose remote we're also remote writing to.
+        remote_write_dsx_relations = [
+            dsx_relations[app_name]
+            for app_name in set(dsx_relations).intersection(remote_write_apps)
+        ]
+
+        # grafana UIDs that are connected to this Tempo.
+        grafana_uids = set(self._get_grafana_source_uids())
+
+        remote_write_dsx_databags = []
+        for relation in remote_write_dsx_relations:
+            try:
+                datasource = DSExchangeAppData.load(relation.data[relation.app])
+                remote_write_dsx_databags.append(datasource)
+            except DataValidationError:
+                # load() already logs
+                continue
+
+        # filter the remote_write_dsx_databags with those that are connected to the same grafana instances Tempo is connected to.
+        matching_datasources = [
+            datasource
+            for databag in remote_write_dsx_databags
+            for datasource in databag.datasources
+            if datasource.grafana_uid in grafana_uids and datasource.type == PROMETHEUS_DS_TYPE
+        ]
+
+        if not matching_datasources:
+            msg = "service graph disabled."
+            missing_rels = []
+            if not remote_write_apps:
+                missing_rels.append("send-remote-write")
+            if not grafana_uids:
+                missing_rels.append("grafana-source")
+            if not dsx_relations:
+                missing_rels.append("receive-datasource")
+
+            if missing_rels:
+                msg += f" Missing relations: {missing_rels}."
+
+            if not remote_write_dsx_relations:
+                msg += " There are no datasource_exchange relations with a Prometheus/Mimir that we're also remote writing to."
+            else:
+                msg += " There are no datasource_exchange relations to a Prometheus/Mimir that are datasources to the same grafana instances Tempo is connected to."
+
+            logger.info(msg)
+            return {}
+
+        if len(matching_datasources) > 1:
+            logger.info(
+                "there are multiple datasources that could be used to create the service graph. We assume that all are equivalent."
+            )
+
+        # At this point, we can assume any datasource is a valid datasource to use for service graphs.
+        matching_datasource = matching_datasources[0]
+        return {
+            "httpMethod": "GET",
+            "serviceMap": {
+                "datasourceUid": matching_datasource.uid,
+            },
+        }
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -128,10 +128,15 @@ class Tempo:
         }
 
     def _build_overrides_config(self):
+        # in order to tell tempo to enable the metrics generator, we need to set
+        # "processors": list of enabled processors in the overrides section
         return tempo_config.Overrides(
             defaults=tempo_config.Defaults(
                 metrics_generator=tempo_config.MetricsGeneratorDefaults(
-                    processors=[tempo_config.MetricsGeneratorProcessor.SPAN_METRICS],
+                    processors=[
+                        tempo_config.MetricsGeneratorProcessorLabel.SPAN_METRICS,
+                        tempo_config.MetricsGeneratorProcessorLabel.SERVICE_GRAPHS,
+                    ],
                 )
             )
         )
@@ -160,11 +165,15 @@ class Tempo:
             storage=tempo_config.MetricsGeneratorStorage(
                 path=self.metrics_generator_wal_path,
                 remote_write=remote_write_instances,
-            )
+            ),
             # Adding juju topology will be done on the worker's side
             # to populate the correct unit label.
+            processor=tempo_config.MetricsGeneratorProcessor(
+                span_metrics=tempo_config.MetricsGeneratorSpanMetricsProcessor(),
+                service_graphs=tempo_config.MetricsGeneratorServiceGraphsProcessor(),
+            ),
+            # per-processor configuration should go in here
         )
-
         return config
 
     def _build_server_config(self, use_tls=False):

--- a/src/tempo_config.py
+++ b/src/tempo_config.py
@@ -9,6 +9,7 @@ from enum import Enum, unique
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import pydantic
 from cosl.coordinated_workers.coordinator import ClusterRolesConfig
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -101,7 +102,7 @@ class ClientAuthTypeEnum(str, enum.Enum):
     REQUIRE_AND_VERIFY_CLIENT_CERT = "RequireAndVerifyClientCert"
 
 
-class MetricsGeneratorProcessor(str, enum.Enum):
+class MetricsGeneratorProcessorLabel(str, enum.Enum):
     """Metrics generator processors supported values.
 
     Supported values: https://grafana.com/docs/tempo/latest/configuration/#standard-overrides
@@ -301,6 +302,29 @@ class RemoteWrite(BaseModel):
     tls_config: Optional[RemoteWriteTLS] = None
 
 
+class MetricsGeneratorSpanMetricsProcessor(BaseModel):
+    """Metrics Generator span_metrics processor configuration schema."""
+
+    # see https://grafana.com/docs/tempo/v2.6.x/configuration/#metrics-generator
+    # for a full list of config options
+
+
+class MetricsGeneratorServiceGraphsProcessor(BaseModel):
+    """Metrics Generator service_graphs processor configuration schema."""
+
+    # see https://grafana.com/docs/tempo/v2.6.x/configuration/#metrics-generator
+    # for a full list of config options
+
+
+class MetricsGeneratorProcessor(BaseModel):
+    """Metrics Generator processor schema."""
+
+    span_metrics: MetricsGeneratorSpanMetricsProcessor
+    service_graphs: MetricsGeneratorServiceGraphsProcessor
+    # see https://grafana.com/docs/tempo/v2.6.x/configuration/#metrics-generator
+    # for a full list of config options; could add local_blocks here
+
+
 class MetricsGeneratorStorage(BaseModel):
     """Metrics Generator storage schema."""
 
@@ -314,6 +338,9 @@ class MetricsGenerator(BaseModel):
     ring: Optional[Ring] = None
     storage: MetricsGeneratorStorage
 
+    # processor-specific config depends on the processor type
+    processor: MetricsGeneratorProcessor
+
 
 class MetricsGeneratorDefaults(BaseModel):
     """Metrics generator defaults schema."""
@@ -323,7 +350,9 @@ class MetricsGeneratorDefaults(BaseModel):
         use_enum_values=True
     )
     """Pydantic config."""
-    processors: List[MetricsGeneratorProcessor]
+    processors: Optional[List[MetricsGeneratorProcessorLabel]] = pydantic.Field(
+        default_factory=list
+    )
 
 
 class Defaults(BaseModel):

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -97,11 +97,6 @@ def patch_all():
         if src_root.exists():
             rmtree(src_root)
 
-        # cleanup: some tests create a spurious src folder for alert rules in ./
-        src_root = pathlib.Path(__file__).parent / "src"
-        if src_root.exists():
-            rmtree(src_root)
-
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
 # this fixture is used by the test runner of charm-relation-interfaces to test tempo's compliance

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -97,6 +97,11 @@ def patch_all():
         if src_root.exists():
             rmtree(src_root)
 
+        # cleanup: some tests create a spurious src folder for alert rules in ./
+        src_root = pathlib.Path(__file__).parent / "src"
+        if src_root.exists():
+            rmtree(src_root)
+
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
 # this fixture is used by the test runner of charm-relation-interfaces to test tempo's compliance

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -21,7 +21,7 @@ def patch_buffer_file_for_charm_tracing(tmp_path):
 
 
 @pytest.fixture(autouse=True, scope="session")
-def cleanup_prometheus_alert_rules(tmp_path):
+def cleanup_prometheus_alert_rules():
     # some tests trigger the charm to generate prometheus alert rules file in ./src; clean it up
     yield
     src_path = Path(__file__).parent / "src"

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -1,13 +1,51 @@
 import json
+from typing import Dict, List
 from unittest.mock import patch
 
+import pytest
 import scenario
-from cosl.interfaces.datasource_exchange import (
-    DatasourceExchange,
-    DSExchangeAppData,
-    GrafanaDatasource,
-)
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from cosl.interfaces.datasource_exchange import DatasourceExchange, GrafanaDatasource
 from scenario import PeerRelation, Relation, State
+
+
+def grafana_source_relation(
+    remote_name: str = "remote",
+    datasource_uids: Dict[str, str] = {"tempo/0": "1234"},
+    grafana_uid: str = "grafana_1",
+):
+    return Relation(
+        "grafana-source",
+        remote_app_name=remote_name,
+        remote_app_data={
+            "datasource_uids": json.dumps(datasource_uids),
+            "grafana_uid": grafana_uid,
+        },
+    )
+
+
+def grafana_datasource_exchange_relation(
+    remote_name: str = "remote",
+    datasources: List[Dict[str, str]] = [
+        {"type": "prometheus", "uid": "prometheus_1", "grafana_uid": "grafana_1"}
+    ],
+):
+    return Relation(
+        "receive-datasource",
+        remote_app_name=remote_name,
+        remote_app_data={"datasources": json.dumps(datasources)},
+    )
+
+
+def remote_write_relation(
+    remote_name: str = "remote",
+    remote_write_data: Dict[str, str] = {"url": "http://prometheus:3000/api/write"},
+):
+    return Relation(
+        "send-remote-write",
+        remote_app_name=remote_name,
+        remote_units_data={0: {"remote_write": json.dumps(remote_write_data)}},
+    )
 
 
 @patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
@@ -28,25 +66,15 @@ def test_datasource_receive(
         {"type": "prometheus", "uid": "8", "grafana_uid": "9"},
     ]
 
-    mimir_dsx = Relation(
-        "receive-datasource",
-        remote_app_data=DSExchangeAppData(
-            datasources=json.dumps(sorted(ds_mimir, key=lambda raw_ds: raw_ds["uid"]))
-        ).dump(),
+    mimir_dsx = grafana_datasource_exchange_relation(
+        datasources=sorted(ds_mimir, key=lambda raw_ds: raw_ds["uid"])
     )
-    loki_dsx = Relation(
-        "receive-datasource",
-        remote_app_data=DSExchangeAppData(
-            datasources=json.dumps(sorted(ds_loki, key=lambda raw_ds: raw_ds["uid"]))
-        ).dump(),
+    loki_dsx = grafana_datasource_exchange_relation(
+        datasources=sorted(ds_loki, key=lambda raw_ds: raw_ds["uid"])
     )
 
-    ds = Relation(
-        "grafana-source",
-        remote_app_data={
-            "grafana_uid": "foo-something-bars",
-            "datasource_uids": json.dumps({"tempo/0": "1234"}),
-        },
+    ds = grafana_source_relation(
+        datasource_uids={"tempo/0": "1234"}, grafana_uid="foo-something-bars"
     )
 
     state_in = State(
@@ -64,16 +92,17 @@ def test_datasource_receive(
     )
 
     # WHEN we receive any event
-    with context(context.on.update_status(), state_in) as mgr:
-        charm = mgr.charm
-        # THEN we can find all received datasource uids in the coordinator
-        dsx: DatasourceExchange = charm.coordinator.datasource_exchange
-        received = dsx.received_datasources
-        assert received == (
-            GrafanaDatasource(type="loki", uid="3", grafana_uid="4"),
-            GrafanaDatasource(type="prometheus", uid="8", grafana_uid="9"),
-        )
-        state_out = mgr.run()
+    with charm_tracing_disabled():
+        with context(context.on.update_status(), state_in) as mgr:
+            charm = mgr.charm
+            # THEN we can find all received datasource uids in the coordinator
+            dsx: DatasourceExchange = charm.coordinator.datasource_exchange
+            received = dsx.received_datasources
+            assert received == (
+                GrafanaDatasource(type="loki", uid="3", grafana_uid="4"),
+                GrafanaDatasource(type="prometheus", uid="8", grafana_uid="9"),
+            )
+            state_out = mgr.run()
 
     # AND THEN we forward our own datasource information to mimir and loki
     assert state_out.unit_status.name == "active"
@@ -85,3 +114,190 @@ def test_datasource_receive(
         "uid": "1234",
         "grafana_uid": "foo-something-bars",
     }
+
+
+@pytest.mark.parametrize("has_dsx", (True, False))
+@pytest.mark.parametrize("has_remote_write", (True, False))
+@pytest.mark.parametrize("has_grafana_source", (True, False))
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_service_graph(
+    workload_ready_mock,
+    has_grafana_source,
+    has_remote_write,
+    has_dsx,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+    ]
+
+    if has_grafana_source:
+        relations.append(grafana_source_relation())
+    if has_dsx:
+        relations.append(grafana_datasource_exchange_relation())
+    if has_remote_write:
+        relations.append(remote_write_relation())
+
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+
+    # WHEN we fire any event
+    with charm_tracing_disabled():
+        with context(context.on.update_status(), state_in) as mgr:
+            mgr.run()
+            charm = mgr.charm
+            service_graph_config = charm._build_service_graph_config()
+
+            # If all relations are there
+            # THEN assert that prometheus ds UID gets populated in the service graph config
+            if all((has_dsx, has_grafana_source, has_remote_write)):
+                assert service_graph_config
+                assert service_graph_config["serviceMap"]["datasourceUid"] == "prometheus_1"
+            # THEN no service graph config will be generated
+            else:
+                assert not service_graph_config
+
+
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_no_service_graph_with_wrong_grafana(
+    workload_ready_mock,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # WHEN tempo is connected as a datasource to multiple grafana instances
+    # AND tempo is connected to multiple "prometheis" instances over datasource exchange
+    # BUT the prometheus instance tempo is connected to over send-remote-write
+    #  is a datasource for a different grafana instance
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+        grafana_source_relation(remote_name="grafana1", grafana_uid="grafana_1"),
+        grafana_source_relation(remote_name="grafana2", grafana_uid="grafana_2"),
+        grafana_datasource_exchange_relation(
+            remote_name="prometheus1",
+            datasources=[
+                {"type": "prometheus", "uid": "prometheus_1", "grafana_uid": "grafana_1"}
+            ],
+        ),
+        grafana_datasource_exchange_relation(
+            remote_name="prometheus2",
+            datasources=[
+                {"type": "prometheus", "uid": "prometheus_2", "grafana_uid": "grafana_3"}
+            ],
+        ),
+        remote_write_relation(remote_name="prometheus2"),
+    ]
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+
+    with charm_tracing_disabled():
+        with context(context.on.update_status(), state_in) as mgr:
+            mgr.run()
+            charm = mgr.charm
+            service_graph_config = charm._build_service_graph_config()
+            # THEN no service graph config should be generated.
+            assert not service_graph_config
+
+
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_service_graph_with_multiple_apps_and_units(
+    workload_ready_mock,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # WHEN tempo is connected to multiple grafanas
+    # AND tempo is connected to a multi-unit prometheus over send-remote-write
+    # AND tempo is connected to prometheus over dsx
+    # AND prometheus is connected to a grafana instance that is common with tempo
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+        grafana_source_relation(remote_name="grafana1", grafana_uid="grafana_1"),
+        grafana_source_relation(remote_name="grafana2", grafana_uid="grafana_2"),
+        grafana_datasource_exchange_relation(
+            remote_name="prometheus1",
+            datasources=[
+                {"type": "prometheus", "uid": "prometheus_1", "grafana_uid": "grafana_1"},
+                {"type": "prometheus", "uid": "prometheus_2", "grafana_uid": "grafana_1"},
+            ],
+        ),
+        remote_write_relation(remote_name="prometheus1"),
+    ]
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+
+    with charm_tracing_disabled():
+        with context(context.on.update_status(), state_in) as mgr:
+            mgr.run()
+            charm = mgr.charm
+            service_graph_config = charm._build_service_graph_config()
+            # THEN a service graph config will be generated containing the datasource UID of any of the 2 prometheis units.
+            assert service_graph_config["serviceMap"]["datasourceUid"] in [
+                "prometheus_1",
+                "prometheus_2",
+            ]
+
+
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_no_service_graph_with_wrong_dsx(
+    workload_ready_mock,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # WHEN tempo is connected to a grafana instance
+    # AND is connected to prometheus over send-remote-write
+    # AND is connected to loki over dsx
+    # BUT is not connected to prometheus over dsx
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+        grafana_source_relation(remote_name="grafana1", grafana_uid="grafana_1"),
+        grafana_datasource_exchange_relation(
+            remote_name="loki1",
+            datasources=[
+                {"type": "loki", "uid": "loki_1", "grafana_uid": "grafana_1"},
+            ],
+        ),
+        remote_write_relation(remote_name="prometheus1"),
+    ]
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+
+    with charm_tracing_disabled():
+        with context(context.on.update_status(), state_in) as mgr:
+            mgr.run()
+            charm = mgr.charm
+            service_graph_config = charm._build_service_graph_config()
+            # THEN a service graph config will not be generated.
+            assert not service_graph_config


### PR DESCRIPTION
it works

![image](https://github.com/user-attachments/assets/6210531b-d779-48e5-a4e9-db3232c1ca06)

but the loki/prom datasource UIDs are hardcoded in the coordinator charm.

Reason for that is ATM we have no way to determine the datasource UIDs for 'other' datsources than ourselves.
We likely need a new relation interface or a clever solution.