### PR TITLE
Add tests for workload tracing in Tempo

### DIFF
--- a/tests/integration/test_self_tracing.py
+++ b/tests/integration/test_self_tracing.py
@@ -92,3 +92,13 @@ async def test_verify_trace_http_remote(ops_test: OpsTest):
 
     # adjust back to the default interval time
     await ops_test.model.set_config({"update-status-hook-interval": "5m"})
+
+
+@pytest.mark.abort_on_fail
+async def test_workload_traces(ops_test: OpsTest):
+    # verify traces from tempo-scalable-single-binary are ingested
+    assert await get_traces_patiently(
+        await get_application_ip(ops_test, APP_NAME),
+        service_name="tempo-scalable-single-binary",
+        tls=False,
+    )

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -175,6 +175,16 @@ async def test_verify_traces_force_enabled_protocols_tls(ops_test: OpsTest, nonc
     await get_traces_patiently(tempo_host, service_name=f"tracegen-{protocol}")
 
 
+@pytest.mark.abort_on_fail
+async def test_workload_traces_tls(ops_test: OpsTest):
+    tempo_host = await get_ingress_proxied_hostname(ops_test)
+    # verify traces from tempo-scalable-single-binary are ingested
+    assert await get_traces_patiently(
+        tempo_host,
+        service_name="tempo-scalable-single-binary",
+    )
+
+
 @pytest.mark.teardown
 @pytest.mark.abort_on_fail
 async def test_remove_relation(ops_test: OpsTest):


### PR DESCRIPTION
This PR adds integration tests to test that internal workload traces from Tempo are getting ingested to itself using both non-encrypted and encrypted (TLS) traffic.

## Testing Considerations
Run the integration tests :D 