### PR TITLE
[DO NOT MERGE] Grafana datasource interface tests

### DIFF
--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,6 +68,24 @@ peers = PeerRelation("peers", peers_data={1: {}})
 k8s_resource_patch_ready = MagicMock(return_value=True)
 
 
+@pytest.fixture(autouse=True, scope="module")
+def patch_all():
+    with ExitStack() as stack:
+        stack.enter_context(patch("lightkube.core.client.GenericSyncClient"))
+        stack.enter_context(
+            patch.multiple(
+                "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                is_ready=k8s_resource_patch_ready,
+                get_status=lambda _: ActiveStatus(""),
+            )
+        )
+        stack.enter_context(charm_tracing_disabled())
+
+        yield
+
+
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
 # this fixture is used by the test runner of charm-relation-interfaces to test tempo's compliance
 # with the interface specifications.
@@ -75,87 +94,51 @@ k8s_resource_patch_ready = MagicMock(return_value=True)
 # to include the new identifier/location.
 @pytest.fixture
 def cluster_tester(interface_tester: InterfaceTester):
-    with patch("lightkube.core.client.GenericSyncClient"):
-        with patch.multiple(
-            "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
-            _namespace="test-namespace",
-            _patch=lambda _: None,
-            is_ready=k8s_resource_patch_ready,
-            get_status=lambda _: ActiveStatus(""),
-        ):
-            with charm_tracing_disabled():
-                interface_tester.configure(
-                    charm_type=TempoCoordinatorCharm,
-                    state_template=State(
-                        leader=True,
-                        containers=[nginx_container, nginx_prometheus_exporter_container],
-                        relations=[peers, s3_relation],
-                    ),
-                )
-                yield interface_tester
+    interface_tester.configure(
+        charm_type=TempoCoordinatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[peers, s3_relation],
+        ),
+    )
+    yield interface_tester
 
 
 @pytest.fixture
 def tracing_tester(interface_tester: InterfaceTester):
-    with patch("lightkube.core.client.GenericSyncClient"):
-        with patch.multiple(
-            "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
-            _namespace="test-namespace",
-            _patch=lambda _: None,
-            is_ready=k8s_resource_patch_ready,
-            get_status=lambda _: ActiveStatus(""),
-        ):
-            with charm_tracing_disabled():
-                interface_tester.configure(
-                    charm_type=TempoCoordinatorCharm,
-                    state_template=State(
-                        leader=True,
-                        containers=[nginx_container, nginx_prometheus_exporter_container],
-                        relations=[peers, s3_relation, cluster_relation],
-                    ),
-                )
-                yield interface_tester
+    interface_tester.configure(
+        charm_type=TempoCoordinatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[peers, s3_relation, cluster_relation],
+        ),
+    )
+    yield interface_tester
 
 
 @pytest.fixture
 def s3_tester(interface_tester: InterfaceTester):
-    with patch("lightkube.core.client.GenericSyncClient"):
-        with patch.multiple(
-            "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
-            _namespace="test-namespace",
-            _patch=lambda _: None,
-            is_ready=k8s_resource_patch_ready,
-            get_status=lambda _: ActiveStatus(""),
-        ):
-            with charm_tracing_disabled():
-                interface_tester.configure(
-                    charm_type=TempoCoordinatorCharm,
-                    state_template=State(
-                        leader=True,
-                        containers=[nginx_container, nginx_prometheus_exporter_container],
-                        relations=[peers, cluster_relation],
-                    ),
-                )
-                yield interface_tester
+    interface_tester.configure(
+        charm_type=TempoCoordinatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[peers, cluster_relation],
+        ),
+    )
+    yield interface_tester
 
 
 @pytest.fixture
 def grafana_datasource_tester(interface_tester: InterfaceTester):
-    with patch("lightkube.core.client.GenericSyncClient"):
-        with patch.multiple(
-            "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
-            _namespace="test-namespace",
-            _patch=lambda _: None,
-            get_status=lambda _: ActiveStatus(""),
-            is_ready=k8s_resource_patch_ready,
-        ):
-            with charm_tracing_disabled():
-                interface_tester.configure(
-                    charm_type=TempoCoordinatorCharm,
-                    state_template=State(
-                        leader=True,
-                        containers=[nginx_container, nginx_prometheus_exporter_container],
-                        relations=[peers, cluster_relation],
-                    ),
-                )
-                yield interface_tester
+    interface_tester.configure(
+        charm_type=TempoCoordinatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[peers, cluster_relation],
+        ),
+    )
+    yield interface_tester

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -155,3 +155,31 @@ def s3_tester(interface_tester: InterfaceTester):
                         ),
                     )
                     yield interface_tester
+
+
+@pytest.fixture
+def grafana_datasource_tester(interface_tester: InterfaceTester):
+    with patch("lightkube.core.client.GenericSyncClient"):
+        with patch.multiple(
+            "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda _: None,
+            is_ready=k8s_resource_patch_ready,
+        ):
+            with patch.multiple(
+                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                get_status=lambda _: ActiveStatus(""),
+                is_ready=k8s_resource_patch_ready,
+            ):
+                with charm_tracing_disabled():
+                    interface_tester.configure(
+                        charm_type=TempoCoordinatorCharm,
+                        state_template=State(
+                            leader=True,
+                            containers=[nginx_container, nginx_prometheus_exporter_container],
+                            relations=[peers, cluster_relation],
+                        ),
+                    )
+                    yield interface_tester

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -81,24 +81,18 @@ def cluster_tester(interface_tester: InterfaceTester):
             _namespace="test-namespace",
             _patch=lambda _: None,
             is_ready=k8s_resource_patch_ready,
+            get_status=lambda _: ActiveStatus(""),
         ):
-            with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                get_status=lambda _: ActiveStatus(""),
-                is_ready=k8s_resource_patch_ready,
-            ):
-                with charm_tracing_disabled():
-                    interface_tester.configure(
-                        charm_type=TempoCoordinatorCharm,
-                        state_template=State(
-                            leader=True,
-                            containers=[nginx_container, nginx_prometheus_exporter_container],
-                            relations=[peers, s3_relation],
-                        ),
-                    )
-                    yield interface_tester
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, s3_relation],
+                    ),
+                )
+                yield interface_tester
 
 
 @pytest.fixture
@@ -109,24 +103,18 @@ def tracing_tester(interface_tester: InterfaceTester):
             _namespace="test-namespace",
             _patch=lambda _: None,
             is_ready=k8s_resource_patch_ready,
+            get_status=lambda _: ActiveStatus(""),
         ):
-            with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                get_status=lambda _: ActiveStatus(""),
-                is_ready=k8s_resource_patch_ready,
-            ):
-                with charm_tracing_disabled():
-                    interface_tester.configure(
-                        charm_type=TempoCoordinatorCharm,
-                        state_template=State(
-                            leader=True,
-                            containers=[nginx_container, nginx_prometheus_exporter_container],
-                            relations=[peers, s3_relation, cluster_relation],
-                        ),
-                    )
-                    yield interface_tester
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, s3_relation, cluster_relation],
+                    ),
+                )
+                yield interface_tester
 
 
 @pytest.fixture
@@ -137,24 +125,18 @@ def s3_tester(interface_tester: InterfaceTester):
             _namespace="test-namespace",
             _patch=lambda _: None,
             is_ready=k8s_resource_patch_ready,
+            get_status=lambda _: ActiveStatus(""),
         ):
-            with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                get_status=lambda _: ActiveStatus(""),
-                is_ready=k8s_resource_patch_ready,
-            ):
-                with charm_tracing_disabled():
-                    interface_tester.configure(
-                        charm_type=TempoCoordinatorCharm,
-                        state_template=State(
-                            leader=True,
-                            containers=[nginx_container, nginx_prometheus_exporter_container],
-                            relations=[peers, cluster_relation],
-                        ),
-                    )
-                    yield interface_tester
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, cluster_relation],
+                    ),
+                )
+                yield interface_tester
 
 
 @pytest.fixture
@@ -164,22 +146,16 @@ def grafana_datasource_tester(interface_tester: InterfaceTester):
             "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
             _namespace="test-namespace",
             _patch=lambda _: None,
+            get_status=lambda _: ActiveStatus(""),
             is_ready=k8s_resource_patch_ready,
         ):
-            with patch.multiple(
-                "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
-                _namespace="test-namespace",
-                _patch=lambda _: None,
-                get_status=lambda _: ActiveStatus(""),
-                is_ready=k8s_resource_patch_ready,
-            ):
-                with charm_tracing_disabled():
-                    interface_tester.configure(
-                        charm_type=TempoCoordinatorCharm,
-                        state_template=State(
-                            leader=True,
-                            containers=[nginx_container, nginx_prometheus_exporter_container],
-                            relations=[peers, cluster_relation],
-                        ),
-                    )
-                    yield interface_tester
+            with charm_tracing_disabled():
+                interface_tester.configure(
+                    charm_type=TempoCoordinatorCharm,
+                    state_template=State(
+                        leader=True,
+                        containers=[nginx_container, nginx_prometheus_exporter_container],
+                        relations=[peers, cluster_relation],
+                    ),
+                )
+                yield interface_tester

--- a/tests/interface/test_grafana_source.py
+++ b/tests/interface/test_grafana_source.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_v0_interface(grafana_datasource_tester: InterfaceTester):
+    grafana_datasource_tester.configure(
+        interface_name="grafana_datasource",
+        branch="grafana-datasource-interface",
+        interface_version=0,
+    )
+    grafana_datasource_tester.run()

--- a/tests/interface/test_tempo_cluster.py
+++ b/tests/interface/test_tempo_cluster.py
@@ -2,10 +2,12 @@
 # See LICENSE file for licensing details.
 from interface_tester import InterfaceTester
 
+from tests.interface.conftest import cluster_tester
 
-def test_tempo_cluster_v0_interface(interface_tester: InterfaceTester):
-    interface_tester.configure(
+
+def test_tempo_cluster_v0_interface(cluster_tester: InterfaceTester):
+    cluster_tester.configure(
         interface_name="tempo_cluster",
         interface_version=0,
     )
-    interface_tester.run()
+    cluster_tester.run()

--- a/tests/interface/test_tempo_cluster.py
+++ b/tests/interface/test_tempo_cluster.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 from interface_tester import InterfaceTester
 
-from tests.interface.conftest import cluster_tester
 
 
 def test_tempo_cluster_v0_interface(cluster_tester: InterfaceTester):

--- a/tests/interface/test_tempo_cluster.py
+++ b/tests/interface/test_tempo_cluster.py
@@ -3,7 +3,6 @@
 from interface_tester import InterfaceTester
 
 
-
 def test_tempo_cluster_v0_interface(cluster_tester: InterfaceTester):
     cluster_tester.configure(
         interface_name="tempo_cluster",

--- a/tests/interface/test_tracing.py
+++ b/tests/interface/test_tracing.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 from interface_tester import InterfaceTester
 
-from tests.interface.conftest import tracing_tester
 
 
 def test_tracing_v2_interface(tracing_tester: InterfaceTester):

--- a/tests/interface/test_tracing.py
+++ b/tests/interface/test_tracing.py
@@ -2,10 +2,12 @@
 # See LICENSE file for licensing details.
 from interface_tester import InterfaceTester
 
+from tests.interface.conftest import tracing_tester
 
-def test_tracing_v2_interface(interface_tester: InterfaceTester):
-    interface_tester.configure(
+
+def test_tracing_v2_interface(tracing_tester: InterfaceTester):
+    tracing_tester.configure(
         interface_name="tracing",
         interface_version=2,
     )
-    interface_tester.run()
+    tracing_tester.run()

--- a/tests/interface/test_tracing.py
+++ b/tests/interface/test_tracing.py
@@ -3,7 +3,6 @@
 from interface_tester import InterfaceTester
 
 
-
 def test_tracing_v2_interface(tracing_tester: InterfaceTester):
     tracing_tester.configure(
         interface_name="tracing",


### PR DESCRIPTION
Interface test fixtures for grafana_source interface tests.

See: https://github.com/canonical/charm-relation-interfaces/pull/204

to test: 
`tox -e interface`

Note that the CRI PR should be merged before this one is. At that point we can remove the tester `branch` pin.

