### PR TITLE
fix(tracing): Don't throw error logs in valid scenarios

### DIFF
--- a/lib/charms/tempo_coordinator_k8s/v0/tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tracing.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["pydantic"]
 
@@ -891,13 +891,15 @@ class TracingEndpointRequirer(Object):
             filter(lambda i: i.protocol.name == protocol, app_data.receivers)
         )
         if not receivers:
-            logger.error(f"no receiver found with protocol={protocol!r}")
+            # it can happen if the charm requests tracing protocols, but the relay (such as grafana-agent) isn't yet
+            # connected to the tracing backend. In this case, it's not an error the charm author can do anything about
+            logger.warning(f"no receiver found with protocol={protocol!r}.")
             return
         if len(receivers) > 1:
-            logger.error(
+            # if we have more than 1 receiver that matches, it shouldn't matter which receiver we'll be using.
+            logger.warning(
                 f"too many receivers with protocol={protocol!r}; using first one. Found: {receivers}"
             )
-            return
 
         receiver = receivers[0]
         return receiver.url


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
While analyzing https://github.com/canonical/grafana-agent-operator/issues/219 with @michaeldmitry  in the context of the k8s charm, we realized some of the logs might be misleading. If the tracing provider cannot (yet) serve any of the requested protocols, the expected outcome would be to return an empty list. Tracing consumer will then throw an error log the charm operator cannot do anything about.

Also we noticed we have an inconsistency in the behaviour when more than 1 receiver of the same protocol would be returned: the log says we're returning the first entry, the actual behaviour is that we exit early.


## Solution
<!-- A summary of the solution addressing the above issue -->
Reduce the logs severity and allow to return the first matching receiver.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
