### PR TITLE
Remove references to old tracing libraries from tempo_k8s namespace

### DIFF
--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -10,10 +10,10 @@ This means that, if your charm is related to, for example, COS' Tempo charm, you
 in real time from the Grafana dashboard the execution flow of your charm.
 
 # Quickstart
-Fetch the following charm libs (and ensure the minimum version/revision numbers are satisfied):
+Fetch the following charm libs:
 
-    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.tracing  # >= 1.10
-    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.charm_tracing  # >= 2.7
+    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.tracing
+    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.charm_tracing
 
 Then edit your charm code to include:
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Our library docstring was pointing at a long gone versions of libraries from `tempo_k8s` namespace which was confusing.


## Solution
<!-- A summary of the solution addressing the above issue -->
Remove the references to the old versions. Fixes #99 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
