### PR TITLE
Stop referring to old and retired library versions

### DIFF
--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -168,9 +168,10 @@ class MyCharm(CharmBase):
     ...
 ```
 
-## Upgrading from `v0`
+## Upgrading from `tempo_k8s.v0`
 
-If you are upgrading from `charm_tracing` v0, you need to take the following steps (assuming you already
+If you are upgrading from `tempo_k8s.v0.charm_tracing` (note that since then, the charm library moved to
+`tempo_coordinator_k8s.v0.charm_tracing`), you need to take the following steps (assuming you already
 have the newest version of the library in your charm):
 1) If you need the dependency for your tests, add the following dependency to your charm project
 (or, if your project had a dependency on `opentelemetry-exporter-otlp-proto-grpc` only because
@@ -183,7 +184,7 @@ to return from ``TracingEndpointRequirer.get_endpoint("otlp_http")`` instead of 
 For example:
 
 ```
-    from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
+    from charms.tempo_k8s.v0.charm_tracing import trace_charm
 
     @trace_charm(
         tracing_endpoint="my_tracing_endpoint",
@@ -337,7 +338,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tracing.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["pydantic"]
 
@@ -951,7 +951,6 @@ def charm_tracing_config(
      proceed with charm tracing (with or without tls, as appropriate)
 
     Usage:
-      If you are using charm_tracing >= v1.9:
     >>> from lib.charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
     >>> from lib.charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
     >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
@@ -961,24 +960,6 @@ def charm_tracing_config(
     >>>         self.tracing = TracingEndpointRequirer(...)
     >>>         self.my_endpoint, self.cert_path = charm_tracing_config(
     ...             self.tracing, self._cert_path)
-
-      If you are using charm_tracing < v1.9:
-    >>> from lib.charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-    >>> from lib.charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
-    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
-    >>> class MyCharm(...):
-    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
-    >>>     def __init__(self, ...):
-    >>>         self.tracing = TracingEndpointRequirer(...)
-    >>>         self._my_endpoint, self._cert_path = charm_tracing_config(
-    ...             self.tracing, self._cert_path)
-    >>>     @property
-    >>>     def my_endpoint(self):
-    >>>         return self._my_endpoint
-    >>>     @property
-    >>>     def cert_path(self):
-    >>>         return self._cert_path
-
     """
     if not endpoint_requirer.is_ready():
         return None, None


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
There was more leftover docstring updates that I noticed after merging #100. Also we were missing a version bump.


## Solution
<!-- A summary of the solution addressing the above issue -->
Stop referring to old and retired library versions and, where it makes sense, take note of lib migration that happened so an entire section only makes sense for those that were on a very old version. Also we don't expect anyone using `charm_tracing_config` to be on very old tracing library versions anymore.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
