### PR TITLE
Enable/Disable IPv6-related nginx config

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -133,8 +133,8 @@ bases:
 parts:
   charm:
     # uncomment this if you add git+ dependencies in requirements.txt:
-    build-packages:
-    - "git"
+    # build-packages:
+    # - "git"
     charm-binary-python-packages:
       - "pydantic>=2"
       - "cryptography"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -133,8 +133,8 @@ bases:
 parts:
   charm:
     # uncomment this if you add git+ dependencies in requirements.txt:
-    # build-packages:
-    # - "git"
+    build-packages:
+    - "git"
     charm-binary-python-packages:
       - "pydantic>=2"
       - "cryptography"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ lightkube>=0.15.4
 lightkube-models>=1.24.1.4
 tenacity==8.2.3
 pydantic>=2
-# TODO update once https://github.com/canonical/cos-lib/pull/128 is merged
-cosl@git+https://github.com/canonical/cos-lib@TAP-296
+cosl>=0.0.55
+
 
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ lightkube>=0.15.4
 lightkube-models>=1.24.1.4
 tenacity==8.2.3
 pydantic>=2
-cosl>=0.0.48
+# TODO update once https://github.com/canonical/cos-lib/pull/128 is merged
+cosl@git+https://github.com/canonical/cos-lib@TAP-296
 
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -302,8 +302,8 @@ class NginxConfig:
                     },
                     {
                         "directive": "ssl_ciphers",
-                        "args": ["HIGH:!aNULL:!MD5"],
-                    },  # codespell:ignore
+                        "args": ["HIGH:!aNULL:!MD5"],  # codespell:ignore
+                    },
                     *self._locations(upstream, grpc, tls),
                 ],
             }

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -13,7 +13,7 @@ from charms.tempo_coordinator_k8s.v0.tracing import (
     receiver_protocol_to_transport_protocol,
 )
 from cosl.coordinated_workers.coordinator import Coordinator
-from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH
+from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH, is_ipv6_enabled
 
 from tempo import Tempo
 from tempo_config import TempoRole
@@ -28,6 +28,7 @@ class NginxConfig:
     def __init__(self, server_name: str):
         self.server_name = server_name
         self.dns_IP_address = _get_dns_ip_address()
+        self.ipv6_enabled = is_ipv6_enabled()
 
     def config(self, coordinator: Coordinator) -> str:
         """Build and return the Nginx configuration."""
@@ -55,7 +56,10 @@ class NginxConfig:
                     # upstreams (load balancing)
                     *self._upstreams(addresses_by_role),
                     # temp paths
-                    {"directive": "client_body_temp_path", "args": ["/tmp/client_temp"]},
+                    {
+                        "directive": "client_body_temp_path",
+                        "args": ["/tmp/client_temp"],
+                    },
                     {"directive": "proxy_temp_path", "args": ["/tmp/proxy_temp_path"]},
                     {"directive": "fastcgi_temp_path", "args": ["/tmp/fastcgi_temp"]},
                     {"directive": "uwsgi_temp_path", "args": ["/tmp/uwsgi_temp"]},
@@ -172,7 +176,10 @@ class NginxConfig:
                 "directive": "location",
                 "args": ["/"],
                 "block": [
-                    {"directive": "set", "args": ["$backend", f"{protocol}://{upstream}"]},
+                    {
+                        "directive": "set",
+                        "args": ["$backend", f"{protocol}://{upstream}"],
+                    },
                     {
                         "directive": "grpc_pass" if grpc else "proxy_pass",
                         "args": ["$backend"],
@@ -191,7 +198,6 @@ class NginxConfig:
         self,
         custom_resolver: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-
         # pass a custom resolver, such as kube-dns.kube-system.svc.cluster.local.
         if custom_resolver:
             return [{"directive": "resolver", "args": [custom_resolver]}]
@@ -220,9 +226,13 @@ class NginxConfig:
         directives.append(
             {"directive": "listen", "args": self._listen_args(port, False, ssl, http2)}
         )
-        directives.append(
-            {"directive": "listen", "args": self._listen_args(port, True, ssl, http2)}
-        )
+        if self.ipv6_enabled:
+            directives.append(
+                {
+                    "directive": "listen",
+                    "args": self._listen_args(port, True, ssl, http2),
+                }
+            )
         return directives
 
     def _listen_args(self, port: int, ipv6: bool, ssl: bool, http2: bool) -> List[str]:
@@ -247,7 +257,10 @@ class NginxConfig:
             for protocol, port in Tempo.receiver_ports.items():
                 servers.append(
                     self._build_server_config(
-                        port, protocol.replace("_", "-"), self._is_protocol_grpc(protocol), tls
+                        port,
+                        protocol.replace("_", "-"),
+                        self._is_protocol_grpc(protocol),
+                        tls,
                     )
                 )
         # generate a server config for the Tempo server protocols (3200, 9096)
@@ -255,7 +268,10 @@ class NginxConfig:
             for protocol, port in Tempo.server_ports.items():
                 servers.append(
                     self._build_server_config(
-                        port, protocol.replace("_", "-"), self._is_protocol_grpc(protocol), tls
+                        port,
+                        protocol.replace("_", "-"),
+                        self._is_protocol_grpc(protocol),
+                        tls,
                     )
                 )
         return servers
@@ -280,8 +296,14 @@ class NginxConfig:
                     {"directive": "server_name", "args": [self.server_name]},
                     {"directive": "ssl_certificate", "args": [CERT_PATH]},
                     {"directive": "ssl_certificate_key", "args": [KEY_PATH]},
-                    {"directive": "ssl_protocols", "args": ["TLSv1", "TLSv1.1", "TLSv1.2"]},
-                    {"directive": "ssl_ciphers", "args": ["HIGH:!aNULL:!MD5"]},  # codespell:ignore
+                    {
+                        "directive": "ssl_protocols",
+                        "args": ["TLSv1", "TLSv1.1", "TLSv1.2"],
+                    },
+                    {
+                        "directive": "ssl_ciphers",
+                        "args": ["HIGH:!aNULL:!MD5"],
+                    },  # codespell:ignore
                     *self._locations(upstream, grpc, tls),
                 ],
             }

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -3,7 +3,7 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import List
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -73,6 +73,7 @@ def test_nginx_config_is_parsed_with_workers(context, nginx_container, coordinat
     assert isinstance(prepared_config, str)
 
 
+@pytest.mark.parametrize("ipv6", (True, False))
 @pytest.mark.parametrize(
     "addresses",
     (
@@ -96,13 +97,14 @@ def test_nginx_config_is_parsed_with_workers(context, nginx_container, coordinat
 )
 @pytest.mark.parametrize("tls", (True, False))
 def test_nginx_config_contains_upstreams_and_proxy_pass(
-    context, nginx_container, coordinator, addresses, tls
+    context, nginx_container, coordinator, addresses, tls, ipv6
 ):
     coordinator.cluster.gather_addresses_by_role.return_value = addresses
     coordinator.nginx.are_certificates_on_disk = tls
 
-    with mock_resolv_conf(f"nameserver {sample_dns_ip}"):
-        nginx = NginxConfig("localhost")
+    with mock_ipv6(ipv6):
+        with mock_resolv_conf(f"nameserver {sample_dns_ip}"):
+            nginx = NginxConfig("localhost")
 
     prepared_config = nginx.config(coordinator)
     assert f"resolver {sample_dns_ip};" in prepared_config
@@ -110,18 +112,19 @@ def test_nginx_config_contains_upstreams_and_proxy_pass(
     for role, addresses in addresses.items():
         for address in addresses:
             if role == "distributor":
-                _assert_config_per_role(Tempo.receiver_ports, address, prepared_config, tls)
+                _assert_config_per_role(Tempo.receiver_ports, address, prepared_config, tls, ipv6)
             if role == "query-frontend":
-                _assert_config_per_role(Tempo.server_ports, address, prepared_config, tls)
+                _assert_config_per_role(Tempo.server_ports, address, prepared_config, tls, ipv6)
 
 
-def _assert_config_per_role(source_dict, address, prepared_config, tls):
+def _assert_config_per_role(source_dict, address, prepared_config, tls, ipv6):
     # as entire config is in a format that's hard to parse (and crossplane returns a string), we look for servers,
     # upstreams and correct proxy/grpc_pass instructions.
     for port in source_dict.values():
         assert f"server {address}:{port};" in prepared_config
         assert f"listen {port}" in prepared_config
-        assert f"listen [::]:{port}" in prepared_config
+        if ipv6:
+            assert f"listen [::]:{port}" in prepared_config
 
     for protocol in source_dict.keys():
         sanitised_protocol = protocol.replace("_", "-")
@@ -143,12 +146,21 @@ def mock_resolv_conf(contents: str):
             yield
 
 
+@contextmanager
+def mock_ipv6(enable: bool):
+    with patch("nginx_config.is_ipv6_enabled", MagicMock(return_value=enable)):
+        yield
+
+
 @pytest.mark.parametrize(
     "mock_contents, expected_dns_ip",
     (
         (f"foo bar\nnameserver {sample_dns_ip}", sample_dns_ip),
         (f"nameserver {sample_dns_ip}\n foo bar baz", sample_dns_ip),
-        (f"foo bar\nfoo bar\nnameserver {sample_dns_ip}\nnameserver 198.18.0.1", sample_dns_ip),
+        (
+            f"foo bar\nfoo bar\nnameserver {sample_dns_ip}\nnameserver 198.18.0.1",
+            sample_dns_ip,
+        ),
     ),
 )
 def test_dns_ip_addr_getter(mock_contents, expected_dns_ip):

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -64,7 +64,9 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, coordina
         },
     ),
 )
-def test_nginx_config_is_parsed_with_workers(context, nginx_container, coordinator, addresses):
+def test_nginx_config_is_parsed_with_workers(
+    context, nginx_container, coordinator, addresses
+):
     coordinator.cluster.gather_addresses_by_role.return_value = addresses
 
     nginx = NginxConfig("localhost")
@@ -112,9 +114,13 @@ def test_nginx_config_contains_upstreams_and_proxy_pass(
     for role, addresses in addresses.items():
         for address in addresses:
             if role == "distributor":
-                _assert_config_per_role(Tempo.receiver_ports, address, prepared_config, tls, ipv6)
+                _assert_config_per_role(
+                    Tempo.receiver_ports, address, prepared_config, tls, ipv6
+                )
             if role == "query-frontend":
-                _assert_config_per_role(Tempo.server_ports, address, prepared_config, tls, ipv6)
+                _assert_config_per_role(
+                    Tempo.server_ports, address, prepared_config, tls, ipv6
+                )
 
 
 def _assert_config_per_role(source_dict, address, prepared_config, tls, ipv6):
@@ -123,8 +129,11 @@ def _assert_config_per_role(source_dict, address, prepared_config, tls, ipv6):
     for port in source_dict.values():
         assert f"server {address}:{port};" in prepared_config
         assert f"listen {port}" in prepared_config
-        if ipv6:
-            assert f"listen [::]:{port}" in prepared_config
+        assert (
+            (f"listen [::]:{port}" in prepared_config)
+            if ipv6
+            else (f"listen [::]:{port}" not in prepared_config)
+        )
 
     for protocol in source_dict.keys():
         sanitised_protocol = protocol.replace("_", "-")

--- a/tests/scenario/test_nginx.py
+++ b/tests/scenario/test_nginx.py
@@ -64,9 +64,7 @@ def test_nginx_config_is_parsed_by_crossplane(context, nginx_container, coordina
         },
     ),
 )
-def test_nginx_config_is_parsed_with_workers(
-    context, nginx_container, coordinator, addresses
-):
+def test_nginx_config_is_parsed_with_workers(context, nginx_container, coordinator, addresses):
     coordinator.cluster.gather_addresses_by_role.return_value = addresses
 
     nginx = NginxConfig("localhost")
@@ -114,13 +112,9 @@ def test_nginx_config_contains_upstreams_and_proxy_pass(
     for role, addresses in addresses.items():
         for address in addresses:
             if role == "distributor":
-                _assert_config_per_role(
-                    Tempo.receiver_ports, address, prepared_config, tls, ipv6
-                )
+                _assert_config_per_role(Tempo.receiver_ports, address, prepared_config, tls, ipv6)
             if role == "query-frontend":
-                _assert_config_per_role(
-                    Tempo.server_ports, address, prepared_config, tls, ipv6
-                )
+                _assert_config_per_role(Tempo.server_ports, address, prepared_config, tls, ipv6)
 
 
 def _assert_config_per_role(source_dict, address, prepared_config, tls, ipv6):


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/cos-lib/issues/127

## Solution
Use https://github.com/canonical/cos-lib/pull/128 utility to check if ipv6 is enabled and listen to the ipv6 addresses accordingly.

## Context
https://github.com/canonical/cos-lib/pull/128

## Testing Instructions
1. [Disable](https://www.techrepublic.com/article/how-to-disable-ipv6-through-grub-in-linux/) ipv6 on the host machine  
2. Reboot your machine
3. Deploy Tempo HA
4. tempo coordinator should be in active/idle and if you `juju ssh --container nginx tempo/0 ss -utpln`, you should not see nginx listening on any ipv6 addresses.
