### PR TITLE
feat: add tempo-api relation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -64,6 +64,10 @@ provides:
     interface: blackbox_exporter_probes
     description: |
       Integration to expose Blackbox Exporter probes for Tempo's reachability.
+  tempo-api:
+    interface: tempo_api
+    description: |
+      Integration to offer other charms the possibility to interact with Tempo's API.
 
 requires:
   self-charm-tracing:

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -173,7 +173,9 @@ class TempoApiRequirer:
         if len(relations) == 0:
             return None
 
-        raw_data_dict = relations[0].data.get(relations[0].app)
+        # Being a little cautious here using getattr and get, since some funny things have happened with relation data
+        # in the past.
+        raw_data_dict = getattr(relations[0], "data", {}).get(relations[0].app)
         if not raw_data_dict:
             return None
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -23,7 +23,7 @@ To use this endpoint wrapper:
 
 * observe the relation-changed event for this relation wherever your charm needs to use this data (this endpoint wrapper DOES
   NOT automatically observe any events)
-* wherever you need access to the data, create a `TempoApiRequirer` instance and use `.get_data()`
+* wherever you need access to the data, call `TempoApiRequirer(...).get_data()`
 
 An example implementation is:
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -1,0 +1,219 @@
+"""tempo_api.
+
+This library implements data accessors the tempo-api interface.  The tempo-api interface is used to
+transfer information about an instance of Tempo, such as how to access and uniquely identify it.  Typically, this is
+useful for charms that create a Tempo instance and want other applications to be able to access it.
+
+## Usage
+
+### Requirer
+
+Add the following to your `charmcraft.yaml` or `metadata.yaml`:
+
+```yaml
+requires:
+  tempo-api:
+    # The example below uses the API for when limit=1.  If you need to support multiple related applications, remove
+    # this and use the list-based data accessor method.
+    limit: 1
+    interface: tempo_api
+```
+
+To implement handling this relation:
+
+* observe the relation-changed event for this relation wherever your charm needs to use this data (this relation DOES
+  NOT automatically observe any events)
+* wherever you need access to the data, create a `TempoApiRequirer` instance and use `.get_data()`
+
+An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.framework.observe(self.on["tempo-api"].relation_changed, self._on_tempo_api_changed)
+
+    def do_something_with_metadata(self):
+        # Get exactly one related application's data, raising if more than one is available
+        tempo_api = TempoApiRequirer(self.model.relations, "tempo-api")
+        metadata = tempo_api.get_data()
+        ...
+```
+
+### Provider
+
+Add the following to your `charmcraft.yaml` or `metadata.yaml`:
+
+```yaml
+provides:
+  tempo-api:
+    interface: tempo_api
+```
+
+To manage sending data to related applications in your charm, use `TempoApiProvider`.  Note that
+`TempoApiProvider` *does not* manage any events, but instead provides a `publish` method for sending data to
+all related applications.  Triggering `publish` appropriately is left to the charm author, although generally you want
+to do this at least during relation_joined and leader_elected events.  An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.tempo_api = TempoApiProvider(
+            relations=self.model.relations,
+            app=self.app,
+            direct_url=self.direct_url,
+            ingress_url=self.external_url,
+            relation_name="tempo-api"
+        )
+
+        self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
+        self.framework.observe(self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish)
+        self.framework.observe(self.on.some_event_that_changes_tempos_url, self.do_something_to_publish)
+```
+"""
+
+import json
+import logging
+from typing import Optional
+
+from ops import Application, RelationMapping
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "6d55454c9a104113b2bd01e738dd5f99"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+PYDEPS = ["pydantic>=2"]
+
+log = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "tempo-api"
+
+
+class TempoApiAppData(BaseModel):
+    """Data model for the tempo-api interface."""
+
+    ingress_url: Optional[AnyHttpUrl] = Field(
+        default=None,
+        description="The non-internal URL at which this application can be reached.  Typically, this is an ingress URL.",
+    )
+    direct_url: AnyHttpUrl = Field(
+        description="The cluster-internal URL at which this application can be reached.  Typically, this is a"
+        " Kubernetes FQDN like name.namespace.svc.cluster.local for connecting to the prometheus api"
+        " from inside the cluster, with scheme."
+    )
+
+
+class TempoApiRequirer:
+    """The requirer side of the tempo-api relation."""
+
+    def __init__(
+        self,
+        relations: RelationMapping,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        """Initialize the TempoApiRequirer object.
+
+        This object is for accessing data from relations that use the tempo-api interface.  It **does not**
+        autonomously handle the events associated with that relation.  It is up to the charm using this object to
+        observe those events as they see fit.  Typically, that charm should observe this relation's relation-changed
+        event.
+
+        This object is for interacting with a relation that has limit=1 set in charmcraft.yaml.  In particular, the
+        get_data method will raise if more than one related application is available.
+
+        Args:
+            relations: The RelationMapping of a charm (typically `self.model.relations` from within a charm object).
+            relation_name: The name of the relation.
+        """
+        self._charm_relation_mapping = relations
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the relation instances for applications related to us on the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    def get_data(self) -> Optional[BaseModel]:
+        """Return data for at most one related application, raising if more than one is available.
+
+        Useful for charms that always expect exactly one related application.  It is recommended that those charms also
+        set limit=1 for that relation in charmcraft.yaml.  Returns None if no data is available (either because no
+        applications are related to us, or because the related application has not sent data).
+        """
+        relations = self.relations
+        if len(relations) == 0:
+            return None
+        if len(relations) > 1:
+            # TODO: Different exception type?
+            raise ValueError("Cannot get_info when more than one application is related.")
+
+        raw_data_dict = relations[0].data.get(relations[0].app)
+        if not raw_data_dict:
+            return None
+
+        # Static analysis errors saying the keys may not be strings.  Protect against this by converting them.
+        raw_data_dict = {str(k): v for k, v in raw_data_dict.items()}
+
+        return TempoApiAppData.model_validate_json(json.dumps(raw_data_dict))  # type: ignore
+
+
+class TempoApiProvider:
+    """The provider side of the tempo-api relation."""
+
+    def __init__(
+        self,
+        relations: RelationMapping,
+        app: Application,
+        direct_url: AnyHttpUrl,
+        ingress_url: Optional[AnyHttpUrl] = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize the TempoApiProvider object.
+
+        This object is for serializing and sending data to a relation that uses the tempo-api interface - it does
+        not automatically observe any events for that relation.  It is up to the charm using this to call publish when
+        it is appropriate to do so, typically on at least the charm's leader_elected event and this relation's
+        relation_joined event.
+
+        Args:
+            relations: The RelationMapping of a charm (typically `self.model.relations` from within a charm object).
+            app: This application.
+            direct_url: The cluster-internal URL at which this application can be reached.  Typically, this is a
+                        Kubernetes FQDN like name.namespace.svc.cluster.local for connecting to the prometheus api
+                        from inside the cluster, with scheme.
+            ingress_url: The non-internal URL at which this application can be reached.  Typically, this is an ingress
+                         URL.
+            relation_name: The name of the relation.
+        """
+        self._charm_relation_mapping = relations
+        self._data = TempoApiAppData(ingress_url=ingress_url, direct_url=direct_url)
+        self._app = app
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the applications related to us under the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    def publish(self):
+        """Post tempo-api to all related applications.
+
+        This method writes to the relation's app data bag, and thus should never be called by a unit that is not the
+        leader otherwise ops will raise an exception.
+        """
+        info_relations = self.relations
+        for relation in info_relations:
+            databag = relation.data[self._app]
+            databag.update(
+                self._data.model_dump(
+                    mode="json", by_alias=True, exclude_defaults=True, round_trip=True
+                )
+            )

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -72,8 +72,7 @@ class FooCharm(CharmBase):
         self.framework.observe(self.on.some_event_that_changes_tempos_url, self.do_something_to_publish)
         
     def do_something_to_publish(self, e):
-        e.publish(...)
-        # or self.tempo_api.publish()...
+        self.tempo_api.publish(...)
 ```
 """
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -19,7 +19,7 @@ requires:
     interface: tempo_api
 ```
 
-To implement handling this relation:
+To use this endpoint wrapper:
 
 * observe the relation-changed event for this relation wherever your charm needs to use this data (this relation DOES
   NOT automatically observe any events)

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -112,7 +112,7 @@ class TempoApiAppData(BaseModel):
 
 
 class TempoApiRequirer:
-    """The requirer side of the tempo-api relation."""
+    """Endpoint wrapper for the requirer side of the tempo-api relation."""
 
     def __init__(
         self,

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -50,7 +50,7 @@ provides:
     interface: tempo_api
 ```
 
-To manage sending data to related applications in your charm, use `TempoApiProvider`.  Note that
+To wrap a provider endpoint for the interface, use the `TempoApiProvider` class.  Note that
 `TempoApiProvider` *does not* manage any events, but instead provides a `publish` method for sending data to
 all related applications.  Triggering `publish` appropriately is left to the charm author, although generally you want
 to do this at least during relation_joined and leader_elected events.  An example implementation is:

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -133,7 +133,7 @@ class TempoApiRequirer:
 
     def __init__(
         self,
-        relations: RelationMapping,
+        relation_mapping: RelationMapping,
         relation_meta: RelationMeta,
     ) -> None:
         """Initialize the TempoApiRequirer object.
@@ -147,11 +147,12 @@ class TempoApiRequirer:
         exception.
 
         Args:
-            relations: The RelationMapping of a charm (typically `self.model.relations` from within a charm object).
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm
+                              object).
             relation_meta: The RelationMeta object for this charm relation (typically
                            `self.meta.relations[relation_name]`).
         """
-        self._charm_relation_mapping = relations
+        self._charm_relation_mapping = relation_mapping
         self._relation_meta = relation_meta
         self._relation_name = self._relation_meta.relation_name
 
@@ -197,7 +198,7 @@ class TempoApiProvider:
 
     def __init__(
         self,
-        relations: RelationMapping,
+        relation_mapping: RelationMapping,
         relation_meta: RelationMeta,
         app: Application,
     ):
@@ -209,12 +210,13 @@ class TempoApiProvider:
         relation_joined event.
 
         Args:
-            relations: The RelationMapping of a charm (typically `self.model.relations` from within a charm object).
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm
+                              object).
             app: This application.
             relation_meta: The RelationMeta object for this charm relation (typically
                `self.meta.relations[relation_name]`).
         """
-        self._charm_relation_mapping = relations
+        self._charm_relation_mapping = relation_mapping
         self._relation_meta = relation_meta
         self._app = app
         self._relation_name = self._relation_meta.relation_name

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -53,7 +53,7 @@ provides:
 To wrap a provider endpoint for the interface, use the `TempoApiProvider` class.  Note that
 `TempoApiProvider` *does not* manage any events, but instead provides a `publish` method for sending data to
 all related applications.  Triggering `publish` appropriately is left to the charm author, although generally you want
-to do this at least during relation_joined and leader_elected events.  An example implementation is:
+to do this at least during the `relation_joined` and `leader_elected` events.  An example implementation is:
 
 ```python
 class FooCharm(CharmBase):

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -1,6 +1,6 @@
 """tempo_api.
 
-This library implements data accessors the tempo-api interface.  The tempo-api interface is used to
+This library implements endpoint wrappers for the tempo-api interface.  The tempo-api interface is used to
 transfer information about an instance of Tempo, such as how to access and uniquely identify it.  Typically, this is
 useful for charms that operate a Tempo instance to give other applications access to [Tempo's HTTP API](https://grafana.com/docs/tempo/latest/api_docs/).
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -181,7 +181,7 @@ class TempoApiRequirer:
         # have the full object
         raw_data_dict = {k: json.loads(v) for k, v in raw_data_dict.items()}
 
-        return TempoApiAppData.model_validate(raw_data_dict)  # type: ignore
+        return TempoApiAppData.model_validate(raw_data_dict)
 
     def _validate_relation_metadata(self):
         """Validate that the provided relation has the correct metadata for this endpoint."""

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -70,6 +70,10 @@ class FooCharm(CharmBase):
         self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
         self.framework.observe(self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish)
         self.framework.observe(self.on.some_event_that_changes_tempos_url, self.do_something_to_publish)
+        
+    def do_something_to_publish(self, e):
+        e.publish(...)
+        # or self.tempo_api.publish()...
 ```
 """
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -177,10 +177,9 @@ class TempoApiRequirer:
         if not raw_data_dict:
             return None
 
-        # Static analysis errors saying the keys may not be strings.  Protect against this by converting them.
         # The data in the databag is in format [str: json-string-of-dict].  Expand out those nested JSON dicts so we
         # have the full object
-        raw_data_dict = {str(k): json.loads(v) for k, v in raw_data_dict.items()}
+        raw_data_dict = {k: json.loads(v) for k, v in raw_data_dict.items()}
 
         return TempoApiAppData.model_validate(raw_data_dict)  # type: ignore
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -27,7 +27,6 @@ class FooCharm(CharmBase):
         self.framework.observe(self.on["tempo-api"].relation_changed, self._on_tempo_api_changed)
 
     def do_something_with_metadata(self):
-        # Get exactly one related application's data, raising if more than one is available
         data = tempo_api.get_data()
         ...
 ```

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -2,7 +2,7 @@
 
 This library implements data accessors the tempo-api interface.  The tempo-api interface is used to
 transfer information about an instance of Tempo, such as how to access and uniquely identify it.  Typically, this is
-useful for charms that create a Tempo instance and want other applications to be able to access it.
+useful for charms that operate a Tempo instance to give other applications access to [Tempo's HTTP API](https://grafana.com/docs/tempo/latest/api_docs/).
 
 ## Usage
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -21,7 +21,7 @@ requires:
 
 To use this endpoint wrapper:
 
-* observe the relation-changed event for this relation wherever your charm needs to use this data (this relation DOES
+* observe the relation-changed event for this relation wherever your charm needs to use this data (this endpoint wrapper DOES
   NOT automatically observe any events)
 * wherever you need access to the data, create a `TempoApiRequirer` instance and use `.get_data()`
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -78,10 +78,10 @@ provides:
 import json
 import logging
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 import yaml
-from ops import Application, RelationMapping
+from ops import Application, RelationMapping, Relation
 from pydantic import AfterValidator, AnyHttpUrl, BaseModel, Field
 from typing_extensions import Annotated
 
@@ -161,9 +161,9 @@ class TempoApiRequirer:
         self._validate_relation_metadata()
 
     @property
-    def relations(self):
+    def relations(self) -> List[Relation]:
         """Return the relation instances for applications related to us on the monitored relation."""
-        return self._charm_relation_mapping.get(self._relation_name, ())
+        return self._charm_relation_mapping.get(self._relation_name, [])
 
     def get_data(self) -> Optional[BaseModel]:
         """Return data from the relation.

--- a/src/charm.py
+++ b/src/charm.py
@@ -353,7 +353,7 @@ class TempoCoordinatorCharm(CharmBase):
         direct_url_http = internal_url + f":{self.tempo.server_ports['tempo_http']}"
         direct_url_grpc = internal_url + f":{self.tempo.server_ports['tempo_grpc']}"
 
-        external_url = self._external_url
+        external_url = self._most_external_url
         if external_url == internal_url:
             # external_url is not set and just defaulted back to internal_url.  Set it to None
             ingress_url_http = None

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,7 +46,6 @@ from tempo_config import TEMPO_ROLES_CONFIG, TempoRole
 logger = logging.getLogger(__name__)
 PEERS_RELATION_ENDPOINT_NAME = "peers"
 PROMETHEUS_DS_TYPE = "prometheus"
-TEMPO_API_RELATION_ENDPOINT_NAME = "tempo-api"
 
 
 class TempoCoordinator(Coordinator):
@@ -351,7 +350,6 @@ class TempoCoordinatorCharm(CharmBase):
             relations=self.model.relations,
             ingress_url=external_url,  # pyright: ignore
             direct_url=internal_url,  # pyright: ignore
-            relation_name=TEMPO_API_RELATION_ENDPOINT_NAME,
             app=self.app,
         )
         tempo_api.publish()

--- a/src/charm.py
+++ b/src/charm.py
@@ -353,14 +353,13 @@ class TempoCoordinatorCharm(CharmBase):
         direct_url_http = internal_url + f":{self.tempo.server_ports['tempo_http']}"
         direct_url_grpc = internal_url + f":{self.tempo.server_ports['tempo_grpc']}"
 
-        external_url = self._most_external_url
-        if external_url == internal_url:
-            # external_url is not set and just defaulted back to internal_url.  Set it to None
-            ingress_url_http = None
-            ingress_url_grpc = None
-        else:
+        external_url = self._external_url
+        if external_url:
             ingress_url_http = external_url + f":{self.tempo.server_ports['tempo_http']}"
             ingress_url_grpc = external_url + f":{self.tempo.server_ports['tempo_grpc']}"
+        else:
+            ingress_url_http = None
+            ingress_url_grpc = None
 
         self.tempo_api.publish(
             direct_url_http=direct_url_http,  # pyright: ignore

--- a/src/charm.py
+++ b/src/charm.py
@@ -168,7 +168,7 @@ class TempoCoordinatorCharm(CharmBase):
         )
 
         self.tempo_api = TempoApiProvider(
-            relations=self.model.relations,
+            relation_mapping=self.model.relations,
             relation_meta=self.meta.relations[tempo_api_relation_name],
             app=self.app,
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -169,7 +169,7 @@ class TempoCoordinatorCharm(CharmBase):
 
         self.tempo_api = TempoApiProvider(
             relation_mapping=self.model.relations,
-            relation_meta=self.meta.relations[tempo_api_relation_name],
+            relation_name=tempo_api_relation_name,
             app=self.app,
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -362,10 +362,10 @@ class TempoCoordinatorCharm(CharmBase):
             ingress_url_grpc = None
 
         self.tempo_api.publish(
-            direct_url_http=direct_url_http,  # pyright: ignore
-            direct_url_grpc=direct_url_grpc,  # pyright: ignore
-            ingress_url_http=ingress_url_http,  # pyright: ignore
-            ingress_url_grpc=ingress_url_grpc,  # pyright: ignore
+            direct_url_http=direct_url_http,
+            direct_url_grpc=direct_url_grpc,
+            ingress_url_http=ingress_url_http,
+            ingress_url_grpc=ingress_url_grpc,
         )
 
     def _update_tracing_relations(self) -> None:

--- a/tests/scenario/test_tempo_api_implementation.py
+++ b/tests/scenario/test_tempo_api_implementation.py
@@ -1,0 +1,137 @@
+"""Tests that assert TempoCoordinatorCharm is wired up correctly to be a tempo-api provider."""
+
+from typing import Optional, Tuple
+from unittest.mock import PropertyMock, patch
+
+from ops.testing import Relation, State
+
+RELATION_NAME = "tempo-api"
+INTERFACE_NAME = "tempo_metadata"
+
+# Note: if this is changed, the TempoApiAppData concrete classes below need to change their constructors to match
+SAMPLE_APP_DATA = {
+    "ingress_url": "http://www.ingress-url.com/",
+    "direct_url": "http://www.internal-url.com/",
+}
+
+TEMPO_COORDINATOR_URL = "http://needs-changing.com/"
+INGRESS_URL = "http://www.ingress-url.com/"
+
+
+def local_app_data_relation_state(
+    leader: bool, local_app_data: Optional[dict] = None
+) -> Tuple[Relation, State]:
+    """Return a testing State that has a single relation with the given local_app_data."""
+    if local_app_data is None:
+        local_app_data = {}
+    else:
+        # Scenario might edit this dict, and it could be used elsewhere
+        local_app_data = dict(local_app_data)
+
+    relation = Relation(RELATION_NAME, INTERFACE_NAME, local_app_data=local_app_data)
+    relations = [relation]
+
+    state = State(
+        relations=relations,
+        leader=leader,
+    )
+
+    return relation, state
+
+
+@patch(
+    "charm.TempoCoordinatorCharm._internal_url", PropertyMock(return_value=TEMPO_COORDINATOR_URL)
+)
+def test_provider_sender_sends_data_on_relation_joined(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
+    """Tests that a charm using TempoApiProvider sends the correct data on a relation joined event."""
+    # Arrange
+    tempo_api = Relation(RELATION_NAME, INTERFACE_NAME)
+    relations = [
+        tempo_api,
+        s3,
+        all_worker,
+    ]
+
+    state = State(
+        relations=relations,
+        leader=True,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+    )
+
+    # Act
+    with context(context.on.relation_joined(tempo_api), state=state) as manager:
+        manager.run()
+        expected = {
+            "direct_url": TEMPO_COORDINATOR_URL,
+        }
+
+    # Assert
+    assert tempo_api.local_app_data == expected
+
+
+@patch("charm.TempoCoordinatorCharm._external_url", PropertyMock(return_value=INGRESS_URL))
+@patch(
+    "charm.TempoCoordinatorCharm._internal_url", PropertyMock(return_value=TEMPO_COORDINATOR_URL)
+)
+def test_provider_sender_sends_data_with_ingress_url_on_relation_joined(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
+    """Tests that a charm using TempoApiProvider with an external url sends the correct data."""
+    # Arrange
+    tempo_api = Relation(RELATION_NAME, INTERFACE_NAME)
+    relations = [
+        tempo_api,
+        s3,
+        all_worker,
+    ]
+
+    state = State(
+        relations=relations,
+        leader=True,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+    )
+
+    # Act
+    with context(context.on.relation_joined(tempo_api), state=state) as manager:
+        manager.run()
+        expected = {
+            "direct_url": TEMPO_COORDINATOR_URL,
+            "ingress_url": INGRESS_URL,
+        }
+
+    # Assert
+    assert tempo_api.local_app_data == expected
+
+
+@patch(
+    "charm.TempoCoordinatorCharm._internal_url", PropertyMock(return_value=TEMPO_COORDINATOR_URL)
+)
+def test_provider_sends_data_on_leader_elected(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
+    """Tests that a charm using TempoApiProvider sends data on a leader elected event."""
+    # Arrange
+    tempo_api = Relation(RELATION_NAME, INTERFACE_NAME)
+    relations = [
+        tempo_api,
+        s3,
+        all_worker,
+    ]
+
+    state = State(
+        relations=relations,
+        leader=True,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+    )
+
+    # Act
+    with context(context.on.leader_elected(), state=state) as manager:
+        manager.run()
+        expected = {
+            "direct_url": TEMPO_COORDINATOR_URL,
+        }
+
+    # Assert
+    assert tempo_api.local_app_data == expected

--- a/tests/scenario/test_tempo_api_implementation.py
+++ b/tests/scenario/test_tempo_api_implementation.py
@@ -1,21 +1,18 @@
 """Tests that assert TempoCoordinatorCharm is wired up correctly to be a tempo-api provider."""
 
+import json
 from typing import Optional, Tuple
 from unittest.mock import PropertyMock, patch
 
 from ops.testing import Relation, State
 
+from tempo import Tempo
+
 RELATION_NAME = "tempo-api"
 INTERFACE_NAME = "tempo_metadata"
 
-# Note: if this is changed, the TempoApiAppData concrete classes below need to change their constructors to match
-SAMPLE_APP_DATA = {
-    "ingress_url": "http://www.ingress-url.com/",
-    "direct_url": "http://www.internal-url.com/",
-}
-
-TEMPO_COORDINATOR_URL = "http://needs-changing.com/"
-INGRESS_URL = "http://www.ingress-url.com/"
+TEMPO_COORDINATOR_URL = "http://needs-changing.com"
+INGRESS_URL = "http://www.ingress-url.com"
 
 
 def local_app_data_relation_state(
@@ -64,7 +61,16 @@ def test_provider_sender_sends_data_on_relation_joined(
     with context(context.on.relation_joined(tempo_api), state=state) as manager:
         manager.run()
         expected = {
-            "direct_url": TEMPO_COORDINATOR_URL,
+            "http": json.dumps(
+                {
+                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
+                }
+            ),
+            "grpc": json.dumps(
+                {
+                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+                }
+            ),
         }
 
     # Assert
@@ -97,8 +103,18 @@ def test_provider_sender_sends_data_with_ingress_url_on_relation_joined(
     with context(context.on.relation_joined(tempo_api), state=state) as manager:
         manager.run()
         expected = {
-            "direct_url": TEMPO_COORDINATOR_URL,
-            "ingress_url": INGRESS_URL,
+            "http": json.dumps(
+                {
+                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
+                    "ingress_url": INGRESS_URL + f":{Tempo.server_ports['tempo_http']}/",
+                }
+            ),
+            "grpc": json.dumps(
+                {
+                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+                    "ingress_url": INGRESS_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+                }
+            ),
         }
 
     # Assert
@@ -130,7 +146,16 @@ def test_provider_sends_data_on_leader_elected(
     with context(context.on.leader_elected(), state=state) as manager:
         manager.run()
         expected = {
-            "direct_url": TEMPO_COORDINATOR_URL,
+            "http": json.dumps(
+                {
+                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
+                }
+            ),
+            "grpc": json.dumps(
+                {
+                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+                }
+            ),
         }
 
     # Assert

--- a/tests/scenario/test_tempo_api_implementation.py
+++ b/tests/scenario/test_tempo_api_implementation.py
@@ -57,24 +57,24 @@ def test_provider_sender_sends_data_on_relation_joined(
         containers=[nginx_container, nginx_prometheus_exporter_container],
     )
 
+    expected = {
+        "http": json.dumps(
+            {
+                "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
+            }
+        ),
+        "grpc": json.dumps(
+            {
+                "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+            }
+        ),
+    }
+
     # Act
-    with context(context.on.relation_joined(tempo_api), state=state) as manager:
-        manager.run()
-        expected = {
-            "http": json.dumps(
-                {
-                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
-                }
-            ),
-            "grpc": json.dumps(
-                {
-                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
-                }
-            ),
-        }
+    state_out = context.run(context.on.relation_joined(tempo_api), state=state)
 
     # Assert
-    assert tempo_api.local_app_data == expected
+    assert state_out.get_relation(tempo_api.id).local_app_data == expected
 
 
 @patch("charm.TempoCoordinatorCharm._external_url", PropertyMock(return_value=INGRESS_URL))
@@ -99,26 +99,26 @@ def test_provider_sender_sends_data_with_ingress_url_on_relation_joined(
         containers=[nginx_container, nginx_prometheus_exporter_container],
     )
 
+    expected = {
+        "http": json.dumps(
+            {
+                "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
+                "ingress_url": INGRESS_URL + f":{Tempo.server_ports['tempo_http']}/",
+            }
+        ),
+        "grpc": json.dumps(
+            {
+                "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+                "ingress_url": INGRESS_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+            }
+        ),
+    }
+
     # Act
-    with context(context.on.relation_joined(tempo_api), state=state) as manager:
-        manager.run()
-        expected = {
-            "http": json.dumps(
-                {
-                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
-                    "ingress_url": INGRESS_URL + f":{Tempo.server_ports['tempo_http']}/",
-                }
-            ),
-            "grpc": json.dumps(
-                {
-                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
-                    "ingress_url": INGRESS_URL + f":{Tempo.server_ports['tempo_grpc']}/",
-                }
-            ),
-        }
+    state_out = context.run(context.on.relation_joined(tempo_api), state=state)
 
     # Assert
-    assert tempo_api.local_app_data == expected
+    assert state_out.get_relation(tempo_api.id).local_app_data == expected
 
 
 @patch(
@@ -142,21 +142,21 @@ def test_provider_sends_data_on_leader_elected(
         containers=[nginx_container, nginx_prometheus_exporter_container],
     )
 
+    expected = {
+        "http": json.dumps(
+            {
+                "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
+            }
+        ),
+        "grpc": json.dumps(
+            {
+                "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
+            }
+        ),
+    }
+
     # Act
-    with context(context.on.leader_elected(), state=state) as manager:
-        manager.run()
-        expected = {
-            "http": json.dumps(
-                {
-                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_http']}/",
-                }
-            ),
-            "grpc": json.dumps(
-                {
-                    "direct_url": TEMPO_COORDINATOR_URL + f":{Tempo.server_ports['tempo_grpc']}/",
-                }
-            ),
-        }
+    state_out = context.run(context.on.leader_elected(), state=state)
 
     # Assert
-    assert tempo_api.local_app_data == expected
+    assert state_out.get_relation(tempo_api.id).local_app_data == expected

--- a/tests/scenario/test_tempo_api_lib.py
+++ b/tests/scenario/test_tempo_api_lib.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Union
+from unittest.mock import patch
 
 import pytest
 from charms.tempo_coordinator_k8s.v0.tempo_api import (
@@ -63,9 +64,7 @@ class TempoApiProviderCharm(CharmBase):
     def __init__(self, framework):
         super().__init__(framework)
         self.relation_provider = TempoApiProvider(
-            self.model.relations,
-            self.meta.relations[RELATION_NAME],
-            app=self.app,
+            self.model.relations, RELATION_NAME, app=self.app
         )
 
 
@@ -82,9 +81,13 @@ class TempoApiRequirerCharm(CharmBase):
 
     def __init__(self, framework):
         super().__init__(framework)
-        self.relation_requirer = TempoApiRequirer(
-            self.model.relations, relation_meta=self.meta.relations[RELATION_NAME]
-        )
+
+        # Skip the validation of relation metadata as it reads a charmcraft.yaml/metadata.yaml file from disk and this
+        # mock requirer doesn't have one
+        with patch.object(TempoApiRequirer, "_validate_relation_metadata", return_value=None):
+            self.relation_requirer = TempoApiRequirer(
+                self.model.relations, relation_name=RELATION_NAME
+            )
 
 
 @pytest.fixture()

--- a/tests/scenario/test_tempo_api_lib.py
+++ b/tests/scenario/test_tempo_api_lib.py
@@ -111,13 +111,14 @@ def test_tempo_api_provider_sends_data_correctly(data, tempo_api_provider_contex
     ) as manager:
         manager.charm.relation_provider.publish(**sample_data_to_tempo_api_publish_args(data))
 
-    # Assert
-    # Convert local_app_data to TempoApiAppData for comparison
-    actual = TempoApiAppData.model_validate(
-        {str(k): json.loads(v) for k, v in tempo_api_relation.local_app_data.items()}
-    )
+        # Assert
+        # Convert local_app_data to TempoApiAppData for comparison
+        tempo_api_relation_out = manager.ops.state.get_relation(tempo_api_relation.id)
+        actual = TempoApiAppData.model_validate(
+            {str(k): json.loads(v) for k, v in tempo_api_relation_out.local_app_data.items()}
+        )
 
-    assert actual == data
+        assert actual == data
 
 
 @pytest.mark.parametrize(

--- a/tests/scenario/test_tempo_api_lib.py
+++ b/tests/scenario/test_tempo_api_lib.py
@@ -38,8 +38,7 @@ SAMPLE_APP_DATA_NO_INGRESS_URL = TempoApiAppData(
 
 
 def data_to_relation_databag(data: TempoApiAppData) -> dict:
-    """Convert a TempoApiAppData to the format expected in a Relation's databag.
-    """
+    """Convert a TempoApiAppData to the format expected in a Relation's databag."""
     data_dict = data.model_dump(mode="json", by_alias=True, exclude_defaults=True, round_trip=True)
     # Flatten any nested objects to json, since relation databags are str:str mappings
     return {k: json.dumps(v) for k, v in data_dict.items()}

--- a/tests/scenario/test_tempo_api_lib.py
+++ b/tests/scenario/test_tempo_api_lib.py
@@ -140,7 +140,7 @@ def test_tempo_api_provider_sends_data_correctly(data, tempo_api_provider_contex
                     remote_app_data=data_to_relation_databag(SAMPLE_APP_DATA),
                 )
             ],
-            SAMPLE_APP_DATA,  # pyright: ignore
+            SAMPLE_APP_DATA,
         ),
         # one populated relation without ingress_url
         (

--- a/tests/scenario/test_tempo_api_lib.py
+++ b/tests/scenario/test_tempo_api_lib.py
@@ -150,7 +150,7 @@ def test_tempo_api_provider_sends_data_correctly(data, tempo_api_provider_contex
                     remote_app_data=data_to_relation_databag(SAMPLE_APP_DATA_NO_INGRESS_URL),
                 )
             ],
-            SAMPLE_APP_DATA_NO_INGRESS_URL,  # pyright: ignore
+            SAMPLE_APP_DATA_NO_INGRESS_URL,
         ),
     ],
 )

--- a/tests/scenario/test_tempo_api_lib.py
+++ b/tests/scenario/test_tempo_api_lib.py
@@ -1,0 +1,223 @@
+"""Tests for the tempo-api lib requirer and provider classes, excluding their usage in the Tempo Coordinator charm."""
+
+from contextlib import nullcontext as does_not_raise
+from typing import Optional, Tuple, Union
+
+import pytest
+from charms.tempo_coordinator_k8s.v0.tempo_api import (
+    TempoApiAppData,
+    TempoApiProvider,
+    TempoApiRequirer,
+)
+from ops import CharmBase
+from ops.testing import Context, Relation, State
+
+RELATION_NAME = "app-data-relation"
+INTERFACE_NAME = "app-data-interface"
+
+# Note: if this is changed, the TempoApiAppData concrete classes below need to change their constructors to match
+SAMPLE_APP_DATA = {
+    "ingress_url": "http://www.ingress-url.com/",
+    "direct_url": "http://www.internal-url.com/",
+}
+SAMPLE_APP_DATA_2 = {
+    "ingress_url": "http://www.ingress-url2.com/",
+    "direct_url": "http://www.internal-url2.com/",
+}
+SAMPLE_APP_DATA_NO_INGRESS_URL = {
+    "direct_url": "http://www.internal-url.com/",
+}
+
+
+class TempoApiProviderCharm(CharmBase):
+    META = {
+        "name": "provider",
+        "provides": {RELATION_NAME: {"interface": RELATION_NAME}},
+    }
+
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.relation_provider = TempoApiProvider(
+            self.model.relations,
+            **SAMPLE_APP_DATA,
+            app=self.app,
+            relation_name=RELATION_NAME,  # pyright: ignore
+        )
+
+
+class TempoApiProviderWithoutIngressCharm(CharmBase):
+    META = {
+        "name": "provider",
+        "provides": {RELATION_NAME: {"interface": RELATION_NAME}},
+    }
+
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.relation_provider = TempoApiProvider(
+            self.model.relations,
+            **SAMPLE_APP_DATA_NO_INGRESS_URL,
+            app=self.app,
+            relation_name=RELATION_NAME,  # pyright: ignore
+        )
+
+
+@pytest.fixture()
+def tempo_api_provider_context():
+    return Context(charm_type=TempoApiProviderCharm, meta=TempoApiProviderCharm.META)
+
+
+@pytest.fixture()
+def tempo_api_provider_without_ingress_context():
+    return Context(charm_type=TempoApiProviderWithoutIngressCharm, meta=TempoApiProviderCharm.META)
+
+
+class TempoApiRequirerCharm(CharmBase):
+    META = {
+        "name": "requirer",
+        "requires": {RELATION_NAME: {"interface": "tempo-api"}},
+    }
+
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.relation_requirer = TempoApiRequirer(
+            self.model.relations, relation_name=RELATION_NAME
+        )
+
+
+@pytest.fixture()
+def tempo_api_requirer_context():
+    return Context(charm_type=TempoApiRequirerCharm, meta=TempoApiRequirerCharm.META)
+
+
+def local_app_data_relation_state(
+    leader: bool, local_app_data: Optional[dict] = None
+) -> Tuple[Relation, State]:
+    """Return a testing State that has a single relation with the given local_app_data."""
+    if local_app_data is None:
+        local_app_data = {}
+    else:
+        # Scenario might edit this dict, and it could be used elsewhere
+        local_app_data = dict(local_app_data)
+
+    relation = Relation(RELATION_NAME, INTERFACE_NAME, local_app_data=local_app_data)
+    relations = [relation]
+
+    state = State(
+        relations=relations,
+        leader=leader,
+    )
+
+    return relation, state
+
+
+def test_tempo_api_provider_sends_data_correctly(tempo_api_provider_context):
+    """Tests that a charm using TempoApiProvider sends the correct data during publish."""
+    # Arrange
+    relation, state = local_app_data_relation_state(leader=True)
+
+    # Act
+    with tempo_api_provider_context(
+        # construct a charm using an event that won't trigger anything here
+        tempo_api_provider_context.on.update_status(),
+        state=state,
+    ) as manager:
+        manager.charm.relation_provider.publish()
+
+    # Assert
+    assert relation.local_app_data == SAMPLE_APP_DATA
+
+
+def test_tempo_api_provider_without_ingress_sends_data_correctly(
+    tempo_api_provider_without_ingress_context,
+):
+    """Tests that a charm using TempoApiProvider without an ingress_url sends the correct data during publish."""
+    # Arrange
+    relation, state = local_app_data_relation_state(leader=True)
+
+    # Act
+    with tempo_api_provider_without_ingress_context(
+        # construct a charm using an event that won't trigger anything here
+        tempo_api_provider_without_ingress_context.on.update_status(),
+        state=state,
+    ) as manager:
+        manager.charm.relation_provider.publish()
+
+    # Assert
+    assert relation.local_app_data == SAMPLE_APP_DATA_NO_INGRESS_URL
+
+
+@pytest.mark.parametrize(
+    "relations, expected_data, context_raised",
+    [
+        ([], None, does_not_raise()),  # no relations
+        (
+            [Relation(RELATION_NAME, INTERFACE_NAME, remote_app_data={})],
+            None,
+            does_not_raise(),
+        ),  # one empty relation
+        (
+            [
+                Relation(
+                    RELATION_NAME,
+                    INTERFACE_NAME,
+                    remote_app_data=SAMPLE_APP_DATA,
+                )
+            ],
+            TempoApiAppData(**SAMPLE_APP_DATA),  # pyright: ignore
+            does_not_raise(),
+        ),  # one populated relation
+        (
+            [
+                Relation(
+                    RELATION_NAME,
+                    INTERFACE_NAME,
+                    remote_app_data=SAMPLE_APP_DATA_NO_INGRESS_URL,
+                )
+            ],
+            TempoApiAppData(**SAMPLE_APP_DATA_NO_INGRESS_URL),  # pyright: ignore
+            does_not_raise(),
+        ),  # one populated relation without ingress_url
+        (
+            [
+                Relation(
+                    RELATION_NAME,
+                    INTERFACE_NAME,
+                    remote_app_data=SAMPLE_APP_DATA,
+                ),
+                Relation(
+                    RELATION_NAME,
+                    INTERFACE_NAME,
+                    remote_app_data=SAMPLE_APP_DATA,
+                ),
+            ],
+            None,
+            pytest.raises(ValueError),
+        ),  # stale data
+    ],
+)
+def test_tempo_api_requirer_get_data(
+    relations, expected_data, context_raised, tempo_api_requirer_context
+):
+    """Tests that TempoApiRequirer.get_data() returns correctly."""
+    state = State(
+        relations=relations,
+        leader=False,
+    )
+
+    with tempo_api_requirer_context(
+        tempo_api_requirer_context.on.update_status(), state=state
+    ) as manager:
+        charm = manager.charm
+
+        with context_raised:
+            data = charm.relation_requirer.get_data()
+            assert are_app_data_equal(data, expected_data)
+
+
+def are_app_data_equal(data1: Union[TempoApiAppData, None], data2: Union[TempoApiAppData, None]):
+    """Compare two TempoApiRequirer objects, tolerating when one or both is None."""
+    if data1 is None and data2 is None:
+        return True
+    if data1 is None or data2 is None:
+        return False
+    return data1.model_dump() == data2.model_dump()


### PR DESCRIPTION
## Issue
For other charms to reach the tempo api (for example, to query tempo), we need to expose that URL (https://github.com/canonical/kiali-k8s-operator/issues/26)

## Solution
This adds the tempo_api.py library that implements data accessors for the tempo-api interface, with data model:

```
class TempoApiAppData(BaseModel):
    """Data model for the tempo-api interface."""

    ingress_url: Optional[AnyHttpUrl] = Field(
        default=None,
        description="The non-internal URL at which this application can be reached.  Typically, this is an ingress URL.",
    )
    direct_url: AnyHttpUrl = Field(
        description="The cluster-internal URL at which this application can be reached.  Typically, this is a"
        " Kubernetes FQDN like name.namespace.svc.cluster.local for connecting to the prometheus api"
        " from inside the cluster, with scheme."
    )
```

## Context

https://github.com/canonical/kiali-k8s-operator/issues/26

## Testing Instructions
Scenario tests should cover the lib (provider and requirer) and the usage of the provider in this charm.  

## Upgrade Notes
