### PR TITLE
refactor: change TempoCoordinatorCharm._external_url, add ._most_external_url

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -94,14 +94,14 @@ class TempoCoordinatorCharm(CharmBase):
         # set the open ports for this unit
         self.unit.set_ports(*self.tempo.all_ports.values())
 
-        self.tracing = TracingEndpointProvider(self, external_url=self._external_url)
+        self.tracing = TracingEndpointProvider(self, external_url=self._most_external_url)
 
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
 
         self.coordinator = TempoCoordinator(
             charm=self,
             roles_config=TEMPO_ROLES_CONFIG,
-            external_url=self._external_url,
+            external_url=self._most_external_url,
             worker_metrics_port=self.tempo.tempo_http_server_port,
             endpoints={
                 "certificates": "certificates",
@@ -167,7 +167,7 @@ class TempoCoordinatorCharm(CharmBase):
     @property
     def _external_hostname(self) -> str:
         """Return the external hostname."""
-        return re.sub(r"^https?:\/\/", "", self._external_url)
+        return re.sub(r"^https?:\/\/", "", self._most_external_url)
 
     @property
     def hostname(self) -> str:
@@ -177,16 +177,29 @@ class TempoCoordinatorCharm(CharmBase):
     @property
     def _external_http_server_url(self) -> str:
         """External url of the http(s) server."""
-        return f"{self._external_url}:{self.tempo.tempo_http_server_port}"
+        return f"{self._most_external_url}:{self.tempo.tempo_http_server_port}"
 
     @property
-    def _external_url(self) -> str:
-        """Return the external url."""
+    def _external_url(self) -> Optional[str]:
+        """Return the external URL if the ingress is configured and ready, otherwise None."""
         if self.ingress.is_ready() and self.ingress.scheme and self.ingress.external_host:
             ingress_url = f"{self.ingress.scheme}://{self.ingress.external_host}"
             logger.debug("This unit's ingress URL: %s", ingress_url)
             return ingress_url
 
+        return None
+
+    @property
+    def _most_external_url(self) -> str:
+        """Return the most external url known about by this charm.
+
+        This will return the first of:
+        - the external URL, if the ingress is configured and ready
+        - the internal URL
+        """
+        external_url = self._external_url
+        if external_url:
+            return external_url
         # If we do not have an ingress, then use the pod hostname.
         # The reason to prefer this over the pod name (which is the actual
         # hostname visible from the pod) or a K8s service, is that those
@@ -247,7 +260,7 @@ class TempoCoordinatorCharm(CharmBase):
             # Unlike Prometheus, Tempo doesn't have a sophisticated web UI.
             # Instead, we'll show the current cluster members and their health status.
             # ref: https://grafana.com/docs/tempo/latest/api_docs/
-            url=f"{self._external_url}:3200/memberlist",
+            url=f"{self._most_external_url}:3200/memberlist",
             description=(
                 "Tempo is a distributed tracing backend by Grafana, supporting Jaeger, "
                 "Zipkin, and OpenTelemetry protocols."


### PR DESCRIPTION
## Issue
Previously, TempoCoordinatorCharm._external_url returned the external url if it was available, otherwise it returned the ingress url.  This meant that any consuming code that explicitly wanted the external_url or nothing needed to duplicate checks that exist in external_url, making it easy to later have these go out of sync.

## Solution
This change breaks _external_url into two functions:
* _external_url, which explicitly returns only an external url or None (if it isn't available)
* _most_external_url, which returns the external_url if it is available, otherwise the internal url

This way the failover behaviour of the previous external_url is preserved, but we can also access exactly the external_url when needed.

## Context
#119's need for knowing exactly the external_url is the driver for this change

## Testing Instructions
Existing CI should cover this.  All that changes here is an intermediate product is also now available

## Upgrade Notes
No effects