### PR TITLE
Feat/open specific worker ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ __pycache__/
 *.egg-info/
 cos-tool-*
 src/prometheus_alert_rules/consolidated_rules/**
+tests/scenario/src/prometheus_alert_rules/consolidated_rules/**
 .terraform*
 *.tfstate*

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -133,8 +133,8 @@ bases:
 parts:
   charm:
     # uncomment this if you add git+ dependencies in requirements.txt:
-    # build-packages:
-    # - "git"
+    build-packages:
+      - "git"
     charm-binary-python-packages:
       - "pydantic>=2"
       - "cryptography"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,29 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 [project]
-name = "tempo-k8s"
+name = "tempo-coordinator-k8s"
 version = "0.1"  # this is in fact irrelevant
+requires-python = ">=3.10"
+
+dependencies = [
+    "ops",
+    "git+https://github.com/canonical/cos-lib@feat/open_specific_worker_ports",
+    "pydantic <3",
+    # ---PYDEPS---
+    # lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+    "opentelemetry-exporter-otlp-proto-http==1.21.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "coverage[toml]",
+    "ops[testing]",
+    "pyright",
+    "ruff"
+]
+
 
 [tool.pyright]
 extraPaths = ["lib"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ lightkube>=0.15.4
 lightkube-models>=1.24.1.4
 tenacity==8.2.3
 pydantic>=2
-cosl>=0.0.48
+git+https://github.com/canonical/cos-lib@feat/open_specific_worker_ports
 
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/scripts/deploy_minio.py
+++ b/scripts/deploy_minio.py
@@ -77,7 +77,7 @@ def deploy(
         try:
             if _check_juju_status(get_s3_status(status), "idle") and _check_workload_status(
                 minio, "active"
-            ):
+            ) and minio.get("address"):
                 break
         except KeyError:
             pass

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,7 +34,7 @@ from ops.charm import CharmBase
 
 from nginx_config import NginxConfig
 from tempo import Tempo
-from tempo_config import TEMPO_ROLES_CONFIG
+from tempo_config import TEMPO_ROLES_CONFIG, TempoRole
 
 logger = logging.getLogger(__name__)
 PEERS_RELATION_ENDPOINT_NAME = "peers"
@@ -83,26 +83,26 @@ class TempoCoordinatorCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
+        # INTEGRATIONS
         self.ingress = TraefikRouteRequirer(self, self.model.get_relation("ingress"), "ingress")  # type: ignore
+        self.tracing = TracingEndpointProvider(self, external_url=self._external_url)
+        # set alert_rules_path="", as we don't want to populate alert rules into the relation databag
+        # we only need `self._remote_write.endpoints`
+        self._remote_write = PrometheusRemoteWriteConsumer(self, alert_rules_path="")
+
         self.tempo = Tempo(
             requested_receivers=self._requested_receivers,
             retention_period_hours=self._trace_retention_period_hours,
         )
-        # set alert_rules_path="", as we don't want to populate alert rules into the relation databag
-        # we only need `self._remote_write.endpoints`
-        self._remote_write = PrometheusRemoteWriteConsumer(self, alert_rules_path="")
-        # set the open ports for this unit
-        self.unit.set_ports(*self.tempo.all_ports.values())
 
-        self.tracing = TracingEndpointProvider(self, external_url=self._external_url)
-
+        # keep this above the coordinator definition
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
 
         self.coordinator = TempoCoordinator(
             charm=self,
             roles_config=TEMPO_ROLES_CONFIG,
             external_url=self._external_url,
-            worker_metrics_port=self.tempo.tempo_http_server_port,
+            worker_metrics_port=Tempo.tempo_http_server_port,
             endpoints={
                 "certificates": "certificates",
                 "cluster": "tempo-cluster",
@@ -123,7 +123,7 @@ class TempoCoordinatorCharm(CharmBase):
             remote_write_endpoints=self.remote_write_endpoints,  # type: ignore
             # TODO: future Tempo releases would be using otlp_xx protocols instead.
             workload_tracing_protocols=["jaeger_thrift_http"],
-            catalogue_item=self._catalogue_item,
+            worker_ports=self._get_worker_ports,
         )
 
         # configure this tempo as a datasource in grafana
@@ -131,15 +131,10 @@ class TempoCoordinatorCharm(CharmBase):
             self,
             source_type="tempo",
             source_url=self._external_http_server_url,
-            refresh_event=[
-                # refresh the source url when TLS config might be changing
-                self.on[self.coordinator.cert_handler.certificates_relation_name].relation_changed,
-                # or when ingress changes
-                self.ingress.on.ready,
-            ],
             extra_fields=self._build_grafana_source_extra_fields(),
         )
 
+        # OBSERVERS
         # peer
         self.framework.observe(
             self.on[PEERS_RELATION_ENDPOINT_NAME].relation_created, self._on_peers_relation_created
@@ -177,7 +172,7 @@ class TempoCoordinatorCharm(CharmBase):
     @property
     def _external_http_server_url(self) -> str:
         """External url of the http(s) server."""
-        return f"{self._external_url}:{self.tempo.tempo_http_server_port}"
+        return f"{self._external_url}:{Tempo.tempo_http_server_port}"
 
     @property
     def _external_url(self) -> str:
@@ -453,7 +448,9 @@ class TempoCoordinatorCharm(CharmBase):
             tls = s = ""
 
         # cert is for fqdn/ingress, not for IP
-        cmd = f"curl{tls} http{s}://{self.coordinator.hostname}:{self.tempo.tempo_http_server_port}/ready"
+        cmd = (
+            f"curl{tls} http{s}://{self.coordinator.hostname}:{Tempo.tempo_http_server_port}/ready"
+        )
 
         try:
             out = getoutput(cmd).split("\n")[-1]
@@ -531,6 +528,8 @@ class TempoCoordinatorCharm(CharmBase):
         # reconcile grafana-source databags to update `extra_fields`
         # if it gets changed by any other influencing relation.
         self._update_grafana_source()
+        # open the necessary ports on this unit
+        self.unit.set_ports(*self._nginx_ports)
 
     def _get_grafana_source_uids(self) -> Dict[str, Dict[str, str]]:
         """Helper method to retrieve the databags of any grafana-source relations.
@@ -662,6 +661,36 @@ class TempoCoordinatorCharm(CharmBase):
             "httpMethod": "GET",
             **svc_graph_config,
         }
+
+    @property
+    def _nginx_ports(self) -> Tuple[int, ...]:
+        """The ports that we should open on this pod."""
+        # we only open the ports that we need to open: that is, the worker ports for all roles.
+        return self._get_worker_ports("all")
+
+    def _get_worker_ports(self, role: str) -> Tuple[int, ...]:
+        """Determine, from the role of a worker, which ports it should open."""
+        # some ports that all workers should open
+        ports: Set[int] = {
+            Tempo.memberlist_port,
+            # we need this because the metrics server is on the same port
+            # technically we don't need it the way things are set up right now, because prometheus
+            # scrapes the worker units over their fqdn, which is an UNIT IP address (not APP), because
+            # juju uses statefulsets and not deployments.
+            Tempo.tempo_http_server_port,
+        }
+
+        tempo_role = TempoRole(role)
+
+        # distributor nodes should be able to accept spans in all supported formats
+        if tempo_role in {TempoRole.all, TempoRole.distributor}:
+            for enabled_receiver in self._requested_receivers():
+                ports.add(Tempo.receiver_ports.get(enabled_receiver))
+
+        # open server ports in query_frontend role
+        if tempo_role in {TempoRole.all, TempoRole.query_frontend}:
+            ports.add(Tempo.tempo_grpc_server_port)
+        return tuple(ports)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -27,25 +27,40 @@ class Tempo:
     wal_path = "/etc/tempo/tempo_wal"
     metrics_generator_wal_path = "/etc/tempo/metrics_generator_wal"
 
+    # this is the single source of truth for which ports are opened and configured
+    # in the distributed Tempo deployment
     memberlist_port = 7946
+    tempo_http_server_port = 3200
+    tempo_grpc_server_port = (
+        9096  # default grpc listen port is 9095, but that conflicts with promtail.
+    )
 
-    server_ports: Dict[str, int] = {
-        "tempo_http": 3200,
-        "tempo_grpc": 9096,  # default grpc listen port is 9095, but that conflicts with promtail.
-    }
-
-    # ports defined are the default ports specified in
+    # these are the default ports specified in
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
     # for each of the below receivers.
-    receiver_ports: Dict[str, int] = {
-        "zipkin": 9411,
-        "otlp_grpc": 4317,
-        "otlp_http": 4318,
-        "jaeger_thrift_http": 14268,
-        "jaeger_grpc": 14250,
-    }
+    zipkin_receiver_port = 9411
+    otlp_grpc_receiver_port = 4317
+    otlp_http_receiver_port = 4318
+    jaeger_thrift_http_receiver_port = 14268
+    jaeger_grpc_receiver_port = 14250
 
-    all_ports = {**server_ports, **receiver_ports}
+    # utility grouping of the ports
+    receiver_ports: Dict[str, int] = {
+        "zipkin": zipkin_receiver_port,
+        "otlp_grpc": otlp_grpc_receiver_port,
+        "otlp_http": otlp_http_receiver_port,
+        "jaeger_thrift_http": jaeger_thrift_http_receiver_port,
+        "jaeger_grpc": jaeger_grpc_receiver_port,
+    }
+    server_ports: Dict[str, int] = {
+        "tempo_http": tempo_http_server_port,
+        "tempo_grpc": tempo_grpc_server_port,
+    }
+    all_ports = {
+        "tempo_http": tempo_http_server_port,
+        "tempo_grpc": tempo_grpc_server_port,
+        **receiver_ports,
+    }
 
     def __init__(
         self,
@@ -54,16 +69,6 @@ class Tempo:
     ):
         self._receivers_getter = requested_receivers
         self._retention_period_hours = retention_period_hours
-
-    @property
-    def tempo_http_server_port(self) -> int:
-        """Return the receiver port for the built-in tempo_http protocol."""
-        return self.server_ports["tempo_http"]
-
-    @property
-    def tempo_grpc_server_port(self) -> int:
-        """Return the receiver port for the built-in tempo_http protocol."""
-        return self.server_ports["tempo_grpc"]
 
     def config(
         self,
@@ -93,7 +98,6 @@ class Tempo:
             config.overrides = self._build_overrides_config()
 
         if coordinator.tls_available:
-
             tls_config = self._build_tls_config(coordinator.cluster.gather_addresses())
 
             config.ingester_client = tempo_config.Client(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -312,7 +312,10 @@ async def deploy_monolithic_cluster(ops_test: OpsTest, tempo_app=APP_NAME):
     """This assumes tempo-coordinator is already deployed as `param:tempo_app`."""
     tempo_worker_charm_url, channel = tempo_worker_charm_and_channel()
     await ops_test.model.deploy(
-        tempo_worker_charm_url, application_name=WORKER_NAME, channel=channel, trust=True
+        tempo_worker_charm_url,
+        application_name=WORKER_NAME,
+        channel=channel,
+        trust=True,
     )
     await ops_test.model.deploy(S3_INTEGRATOR, channel="edge")
 
@@ -350,7 +353,9 @@ async def deploy_distributed_cluster(ops_test: OpsTest, roles: Sequence[str], te
             for role in roles
         ),
         ops_test.model.deploy(S3_INTEGRATOR, channel="edge"),
-        ops_test.model.deploy(PROMETHEUS_CHARM, application_name=PROMETHEUS, channel="edge"),
+        ops_test.model.deploy(
+            PROMETHEUS_CHARM, application_name=PROMETHEUS, channel="edge", trust=True
+        ),
     )
 
     all_workers = tuple(f"{WORKER_NAME}-{role}" for role in roles)
@@ -392,7 +397,12 @@ async def get_traces_patiently(tempo_host, service_name="tracegen-otlp_http", tl
 
 
 async def emit_trace(
-    endpoint, ops_test: OpsTest, nonce: str, proto: str = "otlp_http", verbose=0, use_cert=False
+    endpoint,
+    ops_test: OpsTest,
+    nonce: str,
+    proto: str = "otlp_http",
+    verbose=0,
+    use_cert=False,
 ):
     """Use juju ssh to run tracegen from the tempo charm; to avoid any DNS issues."""
     cmd = (

--- a/tests/integration/test_distributed.py
+++ b/tests/integration/test_distributed.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+from helpers import (
+    APP_NAME,
+    WORKER_NAME,
+    deploy_distributed_cluster,
+    emit_trace,
+    get_application_ip,
+)
+from pytest_operator.plugin import OpsTest
+
+from tempo import Tempo
+from tempo_config import TempoRole
+from tests.integration.helpers import get_resources, get_traces_patiently
+from tests.integration.test_tls import get_tempo_traces_internal_endpoint
+
+ALL_WORKERS = [f"{WORKER_NAME}-" + role for role in TempoRole.all_nonmeta()]
+S3_INTEGRATOR = "s3-integrator"
+TRACEGEN_SCRIPT_PATH = Path() / "scripts" / "tracegen.py"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.setup
+@pytest.mark.abort_on_fail
+async def test_deploy_tempo(ops_test: OpsTest, tempo_charm: Path):
+    await ops_test.model.deploy(
+        tempo_charm, resources=get_resources("."), application_name=APP_NAME, trust=True
+    )
+    await deploy_distributed_cluster(ops_test, TempoRole.all_nonmeta())
+
+
+# TODO: could extend with optional protocols and always-enable them as needed
+@pytest.mark.parametrize("protocol", ("otlp_http",))
+async def test_trace_ingestion(ops_test, protocol, nonce):
+    # WHEN we emit a trace
+    tempo_endpoint = await get_tempo_traces_internal_endpoint(ops_test, protocol=protocol)
+    await emit_trace(tempo_endpoint, ops_test, nonce=nonce, verbose=1, proto=protocol)
+    # THEN we can verify it's been ingested
+    await get_traces_patiently(
+        await get_application_ip(ops_test, APP_NAME), service_name=f"tracegen-{protocol}"
+    )
+
+
+def get_metrics(ip: str, port: int):
+    proc = subprocess.run(shlex.split(f"curl {ip}:{port}/metrics"), text=True, capture_output=True)
+    return proc.stdout
+
+
+@pytest.mark.parametrize("protocol", ("otlp_http",))
+async def test_metrics_endpoints(ops_test, protocol, nonce):
+    # verify that all worker apps and the coordinator can be scraped for metrics on their application IP
+    await asyncio.gather(
+        *(
+            get_metrics(await get_application_ip(ops_test, app), port=Tempo.tempo_http_server_port)
+            for app in (*ALL_WORKERS, APP_NAME)
+        )
+    )
+
+
+@pytest.mark.teardown
+async def test_teardown(ops_test: OpsTest, tempo_charm: Path):
+    await asyncio.gather(
+        *(ops_test.model.remove_application(worker_name) for worker_name in ALL_WORKERS),
+        ops_test.model.remove_application(APP_NAME),
+    )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import WORKER_NAME, deploy_cluster
+from helpers import WORKER_NAME, deploy_monolithic_cluster
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.helpers import get_traces_patiently
@@ -59,7 +59,7 @@ async def test_build_deploy_testers(ops_test: OpsTest, tempo_charm: Path):
         ),
     )
 
-    await deploy_cluster(ops_test)
+    await deploy_monolithic_cluster(ops_test)
 
     await asyncio.gather(
         # for both testers, depending on the result of race with tempo it's either waiting or active

--- a/tests/integration/test_scaling_monolithic.py
+++ b/tests/integration/test_scaling_monolithic.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import deploy_cluster
+from helpers import deploy_monolithic_cluster
 from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
@@ -52,7 +52,7 @@ async def test_scale_tempo_up_without_s3_blocks(ops_test: OpsTest):
 @pytest.mark.setup
 @pytest.mark.abort_on_fail
 async def test_tempo_active_when_deploy_s3_and_workers(ops_test: OpsTest):
-    await deploy_cluster(ops_test)
+    await deploy_monolithic_cluster(ops_test)
 
 
 @pytest.mark.teardown

--- a/tests/integration/test_self_tracing.py
+++ b/tests/integration/test_self_tracing.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from helpers import (
     WORKER_NAME,
-    deploy_cluster,
+    deploy_monolithic_cluster,
     get_application_ip,
     get_traces_patiently,
 )
@@ -42,7 +42,7 @@ async def test_build_and_deploy(ops_test: OpsTest, tempo_charm: Path):
     )
 
     # deploy cluster
-    await deploy_cluster(ops_test, APP_NAME)
+    await deploy_monolithic_cluster(ops_test, APP_NAME)
 
     await asyncio.gather(
         ops_test.model.wait_for_idle(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 from helpers import (
     WORKER_NAME,
-    deploy_cluster,
+    deploy_monolithic_cluster,
     emit_trace,
     get_application_ip,
     get_traces,
@@ -77,7 +77,7 @@ async def test_build_and_deploy(ops_test: OpsTest, tempo_charm: Path):
         SSC_APP_NAME + ":certificates", TRAEFIK_APP_NAME + ":certificates"
     )
     # deploy cluster
-    await deploy_cluster(ops_test)
+    await deploy_monolithic_cluster(ops_test)
 
     await asyncio.gather(
         ops_test.model.wait_for_idle(


### PR DESCRIPTION
## Issue
The coordinator is now responsible for letting the worker know what ports it should be opening.
These have to match with the ones we're forwarding from nginx (and, but that's not as essential, the ingress).

## Testing Instructions
The `test_distributed` integration test should handle it.
If you want to take a look at a deployment model:
`tox -e integration -- -k test_distributed --keep_models`

Tandem PRs:
- https://github.com/canonical/cos-lib/pull/131

## Upgrade Notes
All changes are backwards-compatible.

TODO: merge this after cosl releases, so we can remove the pinned git+ dep