### PR TITLE
Include `metrics-generator` in itests

### DIFF
--- a/tests/integration/test_distributed.py
+++ b/tests/integration/test_distributed.py
@@ -17,14 +17,9 @@ from pytest_operator.plugin import OpsTest
 
 from tempo import Tempo
 from tempo_config import TempoRole
-from tests.integration.helpers import (
-    get_resources,
-    get_traces_patiently,
-)
+from tests.integration.helpers import get_resources, get_traces_patiently
 
-# FIXME: metrics-generator  goes to error state
-# https://github.com/canonical/tempo-worker-k8s-operator/issues/61
-ALL_ROLES = [role for role in TempoRole.all_nonmeta() if role != "metrics-generator"]
+ALL_ROLES = [role for role in TempoRole.all_nonmeta()]
 ALL_WORKERS = [f"{WORKER_NAME}-" + role for role in ALL_ROLES]
 S3_INTEGRATOR = "s3-integrator"
 


### PR DESCRIPTION
## Issue
Due to https://github.com/canonical/tempo-worker-k8s-operator/issues/61, we commented out `metrics-generator` from the itests

## Solution
Include it now after https://github.com/canonical/tempo-worker-k8s-operator/pull/69 is merged

## Context
Needs to be merged first:
- https://github.com/canonical/tempo-worker-k8s-operator/pull/69

## Testing Instructions
itests should pass
