### PR TITLE
Redirect Non-TLS traffic through ingress when TLS is enabled

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -452,6 +452,7 @@ class TempoCoordinatorCharm(CharmBase):
                 if self.ingress.is_ready() and self.ingress.scheme == "https"
                 else {}
             )
+            middlewares.update(redirect_middleware)
 
             http_routers[f"juju-{self.model.name}-{self.model.app.name}-{sanitized_protocol}"] = {
                 "entryPoints": [sanitized_protocol],
@@ -480,8 +481,6 @@ class TempoCoordinatorCharm(CharmBase):
                 http_services[
                     f"juju-{self.model.name}-{self.model.app.name}-service-{sanitized_protocol}"
                 ] = {"loadBalancer": {"servers": self._build_lb_server_config(self._scheme, port)}}
-
-            middlewares.update(redirect_middleware)
 
         return {
             "http": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -436,13 +436,33 @@ class TempoCoordinatorCharm(CharmBase):
         """Build a raw ingress configuration for Traefik."""
         http_routers = {}
         http_services = {}
+        middlewares = {}
         for protocol, port in self.tempo.all_ports.items():
             sanitized_protocol = protocol.replace("_", "-")
+            redirect_middleware = (
+                {
+                    f"juju-{self.model.name}-{self.model.app.name}-middleware-{sanitized_protocol}": {
+                        "redirectScheme": {
+                            "permanent": True,
+                            "port": port,
+                            "scheme": "https",
+                        }
+                    }
+                }
+                if self.ingress.is_ready() and self.ingress.scheme == "https"
+                else {}
+            )
+
             http_routers[f"juju-{self.model.name}-{self.model.app.name}-{sanitized_protocol}"] = {
                 "entryPoints": [sanitized_protocol],
                 "service": f"juju-{self.model.name}-{self.model.app.name}-service-{sanitized_protocol}",
                 # TODO better matcher
                 "rule": "ClientIP(`0.0.0.0/0`)",
+                **(
+                    {"middlewares": list(redirect_middleware.keys())}
+                    if redirect_middleware
+                    else {}
+                ),
             }
             if (
                 protocol == "tempo_grpc"
@@ -460,11 +480,15 @@ class TempoCoordinatorCharm(CharmBase):
                 http_services[
                     f"juju-{self.model.name}-{self.model.app.name}-service-{sanitized_protocol}"
                 ] = {"loadBalancer": {"servers": self._build_lb_server_config(self._scheme, port)}}
+
+            middlewares.update(redirect_middleware)
+
         return {
             "http": {
                 "routers": http_routers,
                 "services": http_services,
-            },
+                "middlewares": middlewares,
+            }
         }
 
     def _build_lb_server_config(self, scheme: str, port: int) -> List[Dict[str, str]]:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -39,6 +39,11 @@ protocols_endpoints = {
     "otlp_grpc": "{hostname}:4317",
 }
 
+api_endpoints = {
+    "tempo_http": "{scheme}://{hostname}:3200/api",
+    "tempo_grpc": "{hostname}:9096",
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -439,7 +444,7 @@ async def get_application_ip(ops_test: OpsTest, app_name: str):
 
 
 def _get_endpoint(protocol: str, hostname: str, tls: bool):
-    protocol_endpoint = protocols_endpoints.get(protocol)
+    protocol_endpoint = protocols_endpoints.get(protocol) or api_endpoints.get(protocol)
     if protocol_endpoint is None:
         assert False, f"Invalid {protocol}"
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -183,6 +183,9 @@ async def test_workload_traces_tls(ops_test: OpsTest):
     set(protocols_endpoints.keys()).union(api_endpoints.keys()),
 )
 async def test_plain_request_redirect(ops_test: OpsTest, protocol):
+    if "grpc" in protocol:
+        # there's no simple way to test with a gRPC client
+        return
     tempo_host = await get_ingress_proxied_hostname(ops_test)
     tempo_endpoint = get_tempo_ingressed_endpoint(tempo_host, protocol=protocol, tls=False)
     req = requests.get(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -3,9 +3,11 @@ import logging
 from pathlib import Path
 
 import pytest
+import requests
 import yaml
 from helpers import (
     WORKER_NAME,
+    api_endpoints,
     deploy_monolithic_cluster,
     emit_trace,
     get_application_ip,
@@ -145,7 +147,12 @@ async def test_force_enable_protocols(ops_test: OpsTest):
 async def test_verify_traces_force_enabled_protocols_tls(ops_test: OpsTest, nonce, protocol):
     tempo_host = await get_ingress_proxied_hostname(ops_test)
     logger.info(f"emitting & verifying trace using {protocol} protocol.")
-    tempo_endpoint = get_tempo_ingressed_endpoint(tempo_host, protocol=protocol, tls=True)
+
+    tempo_endpoint = get_tempo_ingressed_endpoint(
+        tempo_host,
+        protocol=protocol,
+        tls=True,
+    )
     # emit a trace secured with TLS
     await emit_trace(
         tempo_endpoint,
@@ -168,6 +175,23 @@ async def test_workload_traces_tls(ops_test: OpsTest):
         tempo_host,
         service_name="tempo-scalable-single-binary",
     )
+
+
+@pytest.mark.parametrize(
+    "protocol",
+    # test all ports on the coordinator
+    set(protocols_endpoints.keys()).union(api_endpoints.keys()),
+)
+async def test_plain_request_redirect(ops_test: OpsTest, protocol):
+    tempo_host = await get_ingress_proxied_hostname(ops_test)
+    tempo_endpoint = get_tempo_ingressed_endpoint(tempo_host, protocol=protocol, tls=False)
+    req = requests.get(
+        tempo_endpoint,
+        verify=False,
+        allow_redirects=False,
+    )
+    # Permanent Redirect codes
+    assert req.status_code == 301 or req.status_code == 308
 
 
 @pytest.mark.teardown


### PR DESCRIPTION
## Issue
Fixes #116 

## Solution
Add a redirect middleware in traefik_route config for every port tempo exposes.


## Testing Instructions
Run `test_tls.py` itest


