### PR TITLE
Fix `test-against-coordinator` worker CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,7 @@ deps =
 passenv =
     # for faster local itest iterations: pack once, pass the packed charm to pytest with this envvar
     TEMPO_CHARM
+    TEMPO_WORKER_CHARM
 commands =
     pytest -v --tb native --log-cli-level=INFO {[vars]tst_path}integration -s {posargs}
 


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/tempo-worker-k8s-operator/issues/62

## Solution
allow passing `TEMPO_WORKER_CHARM` in `tox.ini`


## Testing Instructions
Pack a worker charm and 
```
export TEMPO_WORKER_CHARM=path/to/packed/charm
tox -e integration
```
You should see in the CI logs that the worker is deployed from local charm as well as the info log `Using local tempo worker char...`

