### PR TITLE
omit middlewares altogether if empty

### DIFF
--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -24,7 +24,9 @@ class FooCharm(CharmBase):
 
         tempo_api = TempoApiRequirer(self.model.relations, "tempo-api")
 
-        self.framework.observe(self.on["tempo-api"].relation_changed, self._on_tempo_api_changed)
+        self.framework.observe(
+            self.on["tempo-api"].relation_changed, self._on_tempo_api_changed
+        )
 
     def do_something_with_metadata(self):
         data = tempo_api.get_data()
@@ -59,8 +61,12 @@ class FooCharm(CharmBase):
         )
 
         self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
-        self.framework.observe(self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish)
-        self.framework.observe(self.on.some_event_that_changes_tempos_url, self.do_something_to_publish)
+        self.framework.observe(
+            self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish
+        )
+        self.framework.observe(
+            self.on.some_event_that_changes_tempos_url, self.do_something_to_publish
+        )
 
     def do_something_to_publish(self, e):
         self.tempo_api.publish(...)
@@ -78,10 +84,10 @@ provides:
 import json
 import logging
 from pathlib import Path
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 import yaml
-from ops import Application, RelationMapping, Relation
+from ops import Application, Relation, RelationMapping
 from pydantic import AfterValidator, AnyHttpUrl, BaseModel, Field
 from typing_extensions import Annotated
 
@@ -93,7 +99,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic>=2"]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,9 @@ from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tempo_api import (
     DEFAULT_RELATION_NAME as tempo_api_relation_name,
 )
-from charms.tempo_coordinator_k8s.v0.tempo_api import TempoApiProvider
+from charms.tempo_coordinator_k8s.v0.tempo_api import (
+    TempoApiProvider,
+)
 from charms.tempo_coordinator_k8s.v0.tracing import (
     ReceiverProtocol,
     TracingEndpointProvider,
@@ -486,7 +488,10 @@ class TempoCoordinatorCharm(CharmBase):
             "http": {
                 "routers": http_routers,
                 "services": http_services,
-                "middlewares": middlewares,
+                # else we get: level=error msg="Error occurred during watcher callback:
+                # ...: middlewares cannot be a standalone element (type map[string]*dynamic.Middleware)"
+                # providerName=file
+                **({"middlewares": middlewares} if middlewares else {}),
             }
         }
 

--- a/tests/scenario/test_ingressed_tracing.py
+++ b/tests/scenario/test_ingressed_tracing.py
@@ -161,7 +161,6 @@ def test_ingress_relation_set_with_dynamic_config(
                     }
                 },
             },
-            "middlewares": {},
         },
     }
 


### PR DESCRIPTION
Fixes an issue with the middlewares definition in traefik-route's config generation.