### PR TITLE
catch modelerrors only on request_protocols call in init

### DIFF
--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -24,7 +24,9 @@ class FooCharm(CharmBase):
 
         tempo_api = TempoApiRequirer(self.model.relations, "tempo-api")
 
-        self.framework.observe(self.on["tempo-api"].relation_changed, self._on_tempo_api_changed)
+        self.framework.observe(
+            self.on["tempo-api"].relation_changed, self._on_tempo_api_changed
+        )
 
     def do_something_with_metadata(self):
         data = tempo_api.get_data()
@@ -59,8 +61,12 @@ class FooCharm(CharmBase):
         )
 
         self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
-        self.framework.observe(self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish)
-        self.framework.observe(self.on.some_event_that_changes_tempos_url, self.do_something_to_publish)
+        self.framework.observe(
+            self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish
+        )
+        self.framework.observe(
+            self.on.some_event_that_changes_tempos_url, self.do_something_to_publish
+        )
 
     def do_something_to_publish(self, e):
         self.tempo_api.publish(...)
@@ -78,10 +84,10 @@ provides:
 import json
 import logging
 from pathlib import Path
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 import yaml
-from ops import Application, RelationMapping, Relation
+from ops import Application, Relation, RelationMapping
 from pydantic import AfterValidator, AnyHttpUrl, BaseModel, Field
 from typing_extensions import Annotated
 
@@ -93,7 +99,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic>=2"]
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tracing.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["pydantic"]
 
@@ -780,7 +780,16 @@ class TracingEndpointRequirer(Object):
         self.framework.observe(events.relation_broken, self._on_tracing_relation_broken)
 
         if protocols:
-            self.request_protocols(protocols)
+            # we can't be sure that the current event context supports read/writing relation data for this relation,
+            # so we catch ModelErrors. This is because we're doing this in init.
+            try:
+                self.request_protocols(protocols)
+            except ModelError as e:
+                logger.error(
+                    f"encountered error {e} while attempting to request_protocols."
+                    f"The relation must be gone."
+                )
+                pass
 
     def request_protocols(
         self, protocols: Sequence[ReceiverProtocol], relation: Optional[Relation] = None
@@ -795,26 +804,11 @@ class TracingEndpointRequirer(Object):
                 "You need to pass a nonempty sequence of protocols to `request_protocols`."
             )
 
-        try:
-            if self._charm.unit.is_leader():
-                for relation in relations:
-                    TracingRequirerAppData(
-                        receivers=list(protocols),
-                    ).dump(relation.data[self._charm.app])
-
-        except ModelError as e:
-            # args are bytes
-            msg = e.args[0]
-            if isinstance(msg, bytes):
-                if msg.startswith(
-                    b"ERROR cannot read relation application settings: permission denied"
-                ):
-                    logger.error(
-                        f"encountered error {e} while attempting to request_protocols."
-                        f"The relation must be gone."
-                    )
-                    return
-            raise
+        if self._charm.unit.is_leader():
+            for relation in relations:
+                TracingRequirerAppData(
+                    receivers=list(protocols),
+                ).dump(relation.data[self._charm.app])
 
     @property
     def relations(self) -> List[Relation]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,9 @@ from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tempo_api import (
     DEFAULT_RELATION_NAME as tempo_api_relation_name,
 )
-from charms.tempo_coordinator_k8s.v0.tempo_api import TempoApiProvider
+from charms.tempo_coordinator_k8s.v0.tempo_api import (
+    TempoApiProvider,
+)
 from charms.tempo_coordinator_k8s.v0.tracing import (
     ReceiverProtocol,
     TracingEndpointProvider,


### PR DESCRIPTION
Fix an issue where request_protocols() would raise a ModelError with an unexpected message if called during `__init__` (when the relation is being removed)

