### PR TITLE
fix: type hinting in TempoApiRequirer

### DIFF
--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -99,7 +99,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["pydantic>=2"]
 
@@ -171,7 +171,7 @@ class TempoApiRequirer:
         """Return the relation instances for applications related to us on the monitored relation."""
         return self._charm_relation_mapping.get(self._relation_name, [])
 
-    def get_data(self) -> Optional[BaseModel]:
+    def get_data(self) -> Optional[TempoApiAppData]:
         """Return data from the relation.
 
         Returns None if no data is available, either because no applications are related to us, or because the related


### PR DESCRIPTION
## Issue
Previously, `get_data(...)` showed that it returned a `BaseModel` when really it returns a `TempoApiAppData`.  This shows up in other charms that use this requirer as a static check error.

## Solution
To fix this, we update the return type hint.


## Context
#119 

## Testing Instructions


## Upgrade Notes
