### PR TITLE
use k8s service as internal url

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -214,6 +214,23 @@ class TempoCoordinatorCharm(CharmBase):
         return socket.getfqdn()
 
     @property
+    def service_hostname(self) -> str:
+        """The FQDN of the k8s service associated with this application.
+        
+        This service load balances traffic across all application units.
+        Falls back to this unit's DNS name if the hostname does not resolve to a Kubernetes-style fqdn. 
+        """
+        # example: 'tempo-0.tempo-headless.default.svc.cluster.local'
+        hostname = self.hostname
+        hostname_parts = hostname.split(".") 
+        if len(hostname_parts) < 6:
+            logger.warning(f"expected K8s-style fqdn, but got {hostname} instead")
+            return hostname
+        _,_,*dns_name_parts = hostname_parts
+        dns_name = '.'.join(dns_name_parts) # 'svc.cluster.local'
+        return f"{self.app.name}.{self.model.name}.{dns_name}" # 'tempo.model.svc.cluster.local'
+    
+    @property
     def _external_http_server_url(self) -> str:
         """External url of the http(s) server."""
         return f"{self._most_external_url}:{Tempo.tempo_http_server_port}"
@@ -239,12 +256,7 @@ class TempoCoordinatorCharm(CharmBase):
         external_url = self._external_url
         if external_url:
             return external_url
-        # If we do not have an ingress, then use the pod hostname.
-        # The reason to prefer this over the pod name (which is the actual
-        # hostname visible from the pod) or a K8s service, is that those
-        # are routable virtually exclusively inside the cluster (as they rely)
-        # on the cluster's DNS service, while the ip address is _sometimes_
-        # routable from the outside, e.g., when deploying on MicroK8s on Linux.
+        # If we do not have an ingress, then use the K8s service.
         return self._internal_url
 
     @property
@@ -257,8 +269,8 @@ class TempoCoordinatorCharm(CharmBase):
 
     @property
     def _internal_url(self) -> str:
-        """Return the locally addressable, FQDN based unit address."""
-        return f"{self._scheme}://{self.hostname}"
+        """Return the locally addressable, FQDN based service address."""
+        return f"{self._scheme}://{self.service_hostname}"
 
     @property
     def are_certificates_on_disk(self) -> bool:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -45,6 +45,15 @@ def test_deploy_monolithic_cluster(juju: Juju, tempo_charm: Path):
     # Then applications should eventually be created
     deploy_monolithic_cluster(juju)
 
+# scaling the coordinator before ingesting traces to verify that scaling won't stop traces ingestion.
+def test_scale_up_tempo(juju: Juju):
+    # GIVEN we scale up tempo
+    juju.add_unit(TEMPO_APP, num_units=2)
+    # THEN all units become active
+    juju.wait(
+        lambda status: jubilant.all_active(status, TEMPO_APP, WORKER_APP, TESTER_APP_NAME, TESTER_GRPC_APP_NAME),
+        timeout=1000
+    )
 
 @pytest.mark.setup
 def test_relate(juju: Juju):
@@ -105,16 +114,6 @@ def test_verify_traces_grpc(juju: Juju):
     assert (
         traces
     ), f"There's no trace of generated grpc traces in tempo. {json.dumps(traces, indent=2)}"
-
-
-def test_scale_up_tempo(juju: Juju):
-    # GIVEN we scale up tempo
-    juju.add_unit(TEMPO_APP, num_units=2)
-    # THEN all units become active
-    juju.wait(
-        lambda status: jubilant.all_active(status, TEMPO_APP, WORKER_APP, TESTER_APP_NAME, TESTER_GRPC_APP_NAME),
-        timeout=1000
-    )
 
 
 @pytest.mark.teardown


### PR DESCRIPTION
Fixes #143 

let the coordinator advertise its `internal_url` as the K8s service (which will by nature loadbalance traffic across all coordinator units.)

## Testing Instructions
Itests should cover testing this change. IMO, we shouldn't be testing that K8s services actually do their job in loadbalancing.
